### PR TITLE
added eor.py for rough sky-locked but noise-like eor signals

### DIFF
--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -6,5 +6,7 @@ import rfi
 import sigchain
 import vis
 import version
+import eor
+
 #import antpos
 __version__ = version.version

--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -7,6 +7,7 @@ import sigchain
 import vis
 import version
 import eor
+import utils
 
 #import antpos
 __version__ = version.version

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -32,7 +32,7 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0, min_dly=0, 
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
 
     # generate white noise
-    vis = noise.white_noise((ntimes, len(fqs)))
+    vis = noise.white_noise((ntimes, len(fqs))) * eor_amp
 
     # Fringe-Rate Filter given baseline
     vis = fg.rough_fringe_filter(vis, lst_grid, fqs, bl_len_ns)

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -1,0 +1,56 @@
+'''A module for generating a rough eor-like signal.'''
+
+import numpy as np
+from scipy.interpolate import RectBivariateSpline
+import aipy
+from . import noise
+from . import foregrounds as fg
+
+
+def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0, min_dly=0, max_dly=3000):
+    """
+    Generate a noise-like EoR signal that tracks the sky.
+    Modeled after foregrounds.diffuse_foreground().
+
+    Args:
+        lsts : ndarray with LSTs [radians]
+        fqs : ndarray with frequencies [GHz]
+        bl_len_ns : float, East-West baseline length [nanosec]
+        eor_amp : float, amplitude of EoR signal [arbitrary]
+        spec_tilt : float, spectral slope of EoR spectral amplitude
+            as a function of delay in microseconds
+        min_dly : float, minimum |delay| in nanosec of EoR signal
+        max_dly : float, maximum |delay| in nanosec of EoR signal
+
+    Returns: 
+        vis : 2D ndarray holding simulated complex visibility
+    """
+    # get fringe rate and generate an LST grid
+    fr_max = np.max(fg.calc_max_fringe_rate(fqs, bl_len_ns))
+    dt = 0.5/fr_max # over-resolve by factor of 2
+    ntimes = int(np.around(aipy.const.sidereal_day / dt))
+    lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
+
+    # generate white noise
+    vis = noise.white_noise((ntimes, len(fqs)))
+
+    # Fringe-Rate Filter given baseline
+    vis = fg.rough_fringe_filter(vis, lst_grid, fqs, bl_len_ns)
+
+    # interpolate at fed LSTs
+    mdl_real = RectBivariateSpline(lst_grid, fqs, vis.real)
+    mdl_imag = RectBivariateSpline(lst_grid, fqs, vis.imag)
+    vis = mdl_real(lsts, fqs) + 1j * mdl_imag(lsts, fqs)
+
+    # introduce a spectral tilt and filter out certain modes
+    visFFT = np.fft.fft(vis, axis=1)
+    dlys = np.abs(np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs))) / 1e3).clip(1e-3, np.inf)
+    visFFT *= dlys ** spec_tilt
+    visFFT[:, dlys < np.abs(min_dly) / 1e3] = 0.0
+    visFFT[:, dlys > np.abs(max_dly) / 1e3] = 0.0
+    vis = np.fft.ifft(visFFT, axis=1)
+
+    return vis
+
+
+

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -10,8 +10,8 @@ from . import utils
 def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
                   fr_width=None, min_dly=0, max_dly=3000, fr_max_mult=2.0):
     """
-    Generate a noise-like EoR signal that tracks the sky.
-    Modeled after foregrounds.diffuse_foreground().
+    Generate a noise-like EoR signal that is fringe-rate filtered
+    according to its projected East-West baseline length.
 
     Args:
         lsts : ndarray with LSTs [radians]
@@ -20,7 +20,7 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
         eor_amp : float, amplitude of EoR signal [arbitrary]
         spec_tilt : float, spectral slope of EoR spectral amplitude
             as a function of delay in microseconds
-        fr_width : float, width of FR filter in 2pi lambda / sec
+        fr_width : float, width of Gaussian FR filter in 1 / sec
         min_dly : float, minimum |delay| in nanosec of EoR signal
         max_dly : float, maximum |delay| in nanosec of EoR signal
         fr_max_mult : float, multiplier of fr_max to get lst_grid resolution
@@ -38,7 +38,7 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
     vis = noise.white_noise((ntimes, len(fqs))) * eor_amp
 
     # Fringe-Rate Filter given baseline
-    vis = utils.rough_fringe_filter(vis, lst_grid, fqs, bl_len_ns, fr_width=fr_width)
+    vis, ff, frs = utils.rough_fringe_filter(vis, lst_grid, fqs, bl_len_ns, fr_width=fr_width)
 
     # interpolate at fed LSTs
     mdl_real = RectBivariateSpline(lst_grid, fqs, vis.real)
@@ -54,6 +54,4 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
     vis = np.fft.ifft(visFFT, axis=1)
 
     return vis
-
-
 

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -8,7 +8,7 @@ from . import utils
 
 
 def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
-                  fr_width=None, min_dly=0, max_dly=3000, fr_max_mult=2.0):
+                  fr_width=None, min_delay=0, max_delay=3000, fr_max_mult=2.0):
     """
     Generate a noise-like EoR signal that is fringe-rate filtered
     according to its projected East-West baseline length.
@@ -21,8 +21,8 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
         spec_tilt : float, spectral slope of EoR spectral amplitude
             as a function of delay in microseconds
         fr_width : float, width of Gaussian FR filter in 1 / sec
-        min_dly : float, minimum |delay| in nanosec of EoR signal
-        max_dly : float, maximum |delay| in nanosec of EoR signal
+        min_delay : float, minimum |delay| in nanosec of EoR signal
+        max_delay : float, maximum |delay| in nanosec of EoR signal
         fr_max_mult : float, multiplier of fr_max to get lst_grid resolution
 
     Returns: 
@@ -47,10 +47,10 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
 
     # introduce a spectral tilt and filter out certain modes
     visFFT = np.fft.fft(vis, axis=1)
-    dlys = np.abs(np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs))) / 1e3).clip(1e-3, np.inf)
-    visFFT *= dlys ** spec_tilt
-    visFFT[:, dlys < np.abs(min_dly) / 1e3] = 0.0
-    visFFT[:, dlys > np.abs(max_dly) / 1e3] = 0.0
+    delays = np.abs(np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs))) / 1e3).clip(1e-3, np.inf)
+    visFFT *= delays ** spec_tilt
+    visFFT[:, delays < np.abs(min_delay) / 1e3] = 0.0
+    visFFT[:, delays > np.abs(max_delay) / 1e3] = 0.0
     vis = np.fft.ifft(visFFT, axis=1)
 
     return vis

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -8,7 +8,7 @@ from . import utils
 
 
 def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
-                  fr_width=None, min_dly=0, max_dly=3000):
+                  fr_width=None, min_dly=0, max_dly=3000, fr_max_mult=2.0):
     """
     Generate a noise-like EoR signal that tracks the sky.
     Modeled after foregrounds.diffuse_foreground().
@@ -23,13 +23,14 @@ def noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0.0,
         fr_width : float, width of FR filter in 2pi lambda / sec
         min_dly : float, minimum |delay| in nanosec of EoR signal
         max_dly : float, maximum |delay| in nanosec of EoR signal
+        fr_max_mult : float, multiplier of fr_max to get lst_grid resolution
 
     Returns: 
         vis : 2D ndarray holding simulated complex visibility
     """
     # get fringe rate and generate an LST grid
     fr_max = np.max(utils.calc_max_fringe_rate(fqs, bl_len_ns))
-    dt = 0.5/fr_max # over-resolve by factor of 2
+    dt = 1.0/(fr_max_mult * fr_max)  # over-resolve by fr_mult factor
     ntimes = int(np.around(aipy.const.sidereal_day / dt))
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
 

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -9,12 +9,15 @@ from . import utils
 
 def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30.,
                        fr_width=None, fr_max_mult=2.0):
+    """
+    Need a doc string...
+    """
     fr_max = np.max(utils.calc_max_fringe_rate(fqs, bl_len_ns))
     dt = 1.0/(fr_max_mult * fr_max)  # over-resolve by fr_mult factor
     ntimes = int(np.around(aipy.const.sidereal_day / dt))
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
     nos = Tsky(lst_grid,fqs) * noise.white_noise((ntimes,fqs.size))
-    nos = utils.rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns, fr_width=fr_width)
+    nos, ff, frs = utils.rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns, fr_width=fr_width)
     nos = utils.rough_delay_filter(nos, fqs, bl_len_ns)
     nos /= noise.jy2T(fqs, bm_poly=bm_poly)
     mdl_real = RectBivariateSpline(lst_grid, fqs, scalar*nos.real)
@@ -23,6 +26,9 @@ def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY,
     
 
 def pntsrc_foreground(lsts, fqs, bl_len_ns, nsrcs=1000):
+    """
+    Need a doc string...
+    """
     ras = np.random.uniform(0,2*np.pi,nsrcs)
     indices = np.random.normal(-1, .5, size=nsrcs)
     mfreq = .15

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -7,9 +7,10 @@ from . import noise
 from . import utils
 
 
-def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30., fr_width=None):
+def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30.,
+                       fr_width=None, fr_max_mult=2.0):
     fr_max = np.max(utils.calc_max_fringe_rate(fqs, bl_len_ns))
-    dt = 0.5/fr_max # over-resolve by factor of 2
+    dt = 1.0/(fr_max_mult * fr_max)  # over-resolve by fr_mult factor
     ntimes = int(np.around(aipy.const.sidereal_day / dt))
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
     nos = Tsky(lst_grid,fqs) * noise.white_noise((ntimes,fqs.size))

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -3,48 +3,23 @@
 import numpy as np
 from scipy.interpolate import RectBivariateSpline
 import aipy
-import noise
+from . import noise
+from . import utils
 
-def rough_delay_filter(noise, fqs, bl_len_ns):
-    dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
-    _noise = np.fft.fft(noise)
-    dly_filter = np.exp(-dlys**2 / (2*bl_len_ns**2))
-    dly_filter.shape = (1,) * (_noise.ndim-1) + (-1,)
-    return np.fft.ifft(_noise * dly_filter)
 
-def calc_max_fringe_rate(fqs, bl_len_ns):
-    bl_wavelen = fqs * bl_len_ns
-    fr_max = 2*np.pi/aipy.const.sidereal_day * bl_wavelen
-    return fr_max
-
-def rough_fringe_filter(noise, lsts, fqs, bl_len_ns):
-    fr_max = calc_max_fringe_rate(fqs, bl_len_ns)
-    fr_max.shape = (1,) * (noise.ndim-1) + (-1,)
-    times = lsts / (2*np.pi) * aipy.const.sidereal_day
-    fringe_rates = np.fft.fftfreq(times.size, times[1]-times[0])
-    fringe_rates.shape = (-1,) + (1,) * (noise.ndim-1)
-    _noise = np.fft.fft(noise, axis=-2)
-    fng_filter = np.where(np.abs(fringe_rates) < fr_max, 1., 0)
-    return np.fft.ifft(_noise * fng_filter, axis=-2)
-    
 def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30.):
-    fr_max = np.max(calc_max_fringe_rate(fqs, bl_len_ns))
+    fr_max = np.max(utils.calc_max_fringe_rate(fqs, bl_len_ns))
     dt = 0.5/fr_max # over-resolve by factor of 2
     ntimes = int(np.around(aipy.const.sidereal_day / dt))
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
     nos = Tsky(lst_grid,fqs) * noise.white_noise((ntimes,fqs.size))
-    nos = rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns)
-    nos = rough_delay_filter(nos, fqs, bl_len_ns)
+    nos = utils.rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns)
+    nos = utils.rough_delay_filter(nos, fqs, bl_len_ns)
     nos /= noise.jy2T(fqs, bm_poly=bm_poly)
     mdl_real = RectBivariateSpline(lst_grid, fqs, scalar*nos.real)
     mdl_imag = RectBivariateSpline(lst_grid, fqs, scalar*nos.imag)
     return mdl_real(lsts,fqs) + 1j*mdl_imag(lsts,fqs)
     
-def compute_ha(lsts, ra):
-    ha = lsts - ra
-    ha = np.where(ha > np.pi, ha-2*np.pi, ha)
-    ha = np.where(ha < -np.pi, ha+2*np.pi, ha)
-    return ha
 
 def pntsrc_foreground(lsts, fqs, bl_len_ns, nsrcs=1000):
     ras = np.random.uniform(0,2*np.pi,nsrcs)
@@ -56,10 +31,10 @@ def pntsrc_foreground(lsts, fqs, bl_len_ns, nsrcs=1000):
     flux_densities = ((x1**(n+1) - x0**(n+1))*np.random.uniform(size=nsrcs) + x0**(n+1))**(1./(n+1))
     vis = np.zeros((lsts.size, fqs.size), dtype=np.complex)
     for ra,flux,index in zip(ras,flux_densities,indices):
-        t = np.argmin(np.abs(compute_ha(lsts,ra)))
+        t = np.argmin(np.abs(utils.compute_ha(lsts,ra)))
         dtau = np.random.uniform(-.1*bl_len_ns,.1*bl_len_ns) # XXX adds a bit to total delay, increasing bl_len_ns
         vis[t,:] += flux * (fqs/mfreq)**index * np.exp(2j*np.pi*fqs*dtau)
-    ha = compute_ha(lsts, 0)
+    ha = utils.compute_ha(lsts, 0)
     for fi in xrange(fqs.size):
         bm = np.exp(-ha**2 / (2*beam_width[fi]**2))
         bm = np.where(np.abs(ha) > np.pi/2, 0, bm)

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -7,13 +7,13 @@ from . import noise
 from . import utils
 
 
-def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30.):
+def diffuse_foreground(Tsky, lsts, fqs, bl_len_ns, bm_poly=noise.HERA_BEAM_POLY, scalar=30., fr_width=None):
     fr_max = np.max(utils.calc_max_fringe_rate(fqs, bl_len_ns))
     dt = 0.5/fr_max # over-resolve by factor of 2
     ntimes = int(np.around(aipy.const.sidereal_day / dt))
     lst_grid = np.linspace(0, 2*np.pi, ntimes, endpoint=False)
     nos = Tsky(lst_grid,fqs) * noise.white_noise((ntimes,fqs.size))
-    nos = utils.rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns)
+    nos = utils.rough_fringe_filter(nos, lst_grid, fqs, bl_len_ns, fr_width=fr_width)
     nos = utils.rough_delay_filter(nos, fqs, bl_len_ns)
     nos /= noise.jy2T(fqs, bm_poly=bm_poly)
     mdl_real = RectBivariateSpline(lst_grid, fqs, scalar*nos.real)

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -1,6 +1,6 @@
 '''A module for modeling HERA signal chains.'''
 
-import noise
+from . import noise
 import numpy as np
 import aipy
 

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -15,7 +15,7 @@ class TestForegrounds(unittest.TestCase):
         bl_len_ns = 50.
 
         # Simulate vanilla eor
-        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_dly=0, max_dly=1e5)
+        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_delay=0, max_delay=1e5)
 
         # assert covariance across freq is close to diagonal (i.e. frequency covariance is essentially noise-like)
         cov = np.cov(vis.T)
@@ -34,18 +34,18 @@ class TestForegrounds(unittest.TestCase):
         # Introduce a spectral tilt: generally EoR is flat-ish in Delta^2 and therefore
         # follows a negative power-law in P(k)
         lsts = np.linspace(0, 2*np.pi, 1000)
-        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=-2, min_dly=200, max_dly=500)
+        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=-2, min_delay=200, max_delay=500)
 
         # take FFT and incoherently average over time to check spectral tilt
         vfft = np.mean(np.abs(np.fft.fft(vis, axis=1)), axis=0)
-        dlys = np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs)))
-        select = (dlys > 200) & (dlys < 500)
-        fit = np.polyfit(np.log10(dlys[select]), np.log10(vfft[select]), 1)
+        delays = np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs)))
+        select = (delays > 200) & (delays < 500)
+        fit = np.polyfit(np.log10(delays[select]), np.log10(vfft[select]), 1)
         nt.assert_almost_equal(fit[0], -2, places=1)
 
         # test amplitude scaling is correct
-        vis1 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_dly=200, max_dly=500)
-        vis2 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-3, spec_tilt=0, min_dly=200, max_dly=500)
+        vis1 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_delay=200, max_delay=500)
+        vis2 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-3, spec_tilt=0, min_delay=200, max_delay=500)
         nt.assert_almost_equal(np.mean(np.abs(vis1 / vis2)) / np.sqrt(2), 1e-2, places=2)
 
 

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -43,6 +43,11 @@ class TestForegrounds(unittest.TestCase):
         fit = np.polyfit(np.log10(dlys[select]), np.log10(vfft[select]), 1)
         nt.assert_almost_equal(fit[0], -2, places=1)
 
+        # test amplitude scaling is correct
+        vis1 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_dly=200, max_dly=500)
+        vis2 = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-3, spec_tilt=0, min_dly=200, max_dly=500)
+        nt.assert_almost_equal(np.mean(np.abs(vis1 / vis2)) / np.sqrt(2), 1e-2, places=2)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -33,6 +33,7 @@ class TestForegrounds(unittest.TestCase):
 
         # Introduce a spectral tilt: generally EoR is flat-ish in Delta^2 and therefore
         # follows a negative power-law in P(k)
+        lsts = np.linspace(0, 2*np.pi, 1000)
         vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=-2, min_dly=200, max_dly=500)
 
         # take FFT and incoherently average over time to check spectral tilt

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -1,0 +1,47 @@
+import unittest
+from hera_sim import eor
+import numpy as np
+import aipy
+import nose.tools as nt
+
+np.random.seed(0)
+
+class TestForegrounds(unittest.TestCase):
+    def test_noiselike_eor(self):
+        # setup simulation parameters
+        fqs = np.linspace(.1, .2, 201, endpoint=False)
+        lsts = np.linspace(0, 1, 100)
+        times = lsts / (2*np.pi) * aipy.const.sidereal_day
+        bl_len_ns = 50.
+
+        # Simulate vanilla eor
+        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=0, min_dly=0, max_dly=1e5)
+
+        # assert covariance across freq is close to diagonal (i.e. frequency covariance is essentially noise-like)
+        cov = np.cov(vis.T)
+        mean_diag = np.mean(cov.diagonal())
+        mean_offdiag = np.mean(cov - np.eye(len(cov)) * cov.diagonal())
+        nt.assert_true(np.abs(mean_diag / mean_offdiag) > 1e3)
+        # Look at it manually to check: plt.matshow(np.abs(cov))
+
+        # assert covariance across time has some non-neglible off diagonal (i.e. sky locked)
+        cov = np.cov(vis)
+        mean_diag = np.mean(cov.diagonal())
+        mean_offdiag = np.mean(cov - np.eye(len(cov)) * cov.diagonal())
+        nt.assert_true(np.abs(mean_diag / mean_offdiag) < 20)
+        # Look at it manually to check: plt.matshow(np.abs(cov))
+
+        # Introduce a spectral tilt: generally EoR is flat-ish in Delta^2 and therefore
+        # follows a negative power-law in P(k)
+        vis = eor.noiselike_eor(lsts, fqs, bl_len_ns, eor_amp=1e-5, spec_tilt=-2, min_dly=200, max_dly=500)
+
+        # take FFT and incoherently average over time to check spectral tilt
+        vfft = np.mean(np.abs(np.fft.fft(vis, axis=1)), axis=0)
+        dlys = np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs)))
+        select = (dlys > 200) & (dlys < 500)
+        fit = np.polyfit(np.log10(dlys[select]), np.log10(vfft[select]), 1)
+        nt.assert_almost_equal(fit[0], -2, places=1)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/hera_sim/tests/test_foregrounds.py
+++ b/hera_sim/tests/test_foregrounds.py
@@ -1,5 +1,5 @@
 import unittest
-from hera_sim import noise, foregrounds
+from hera_sim import noise, foregrounds, utils
 import numpy as np
 import aipy
 
@@ -11,7 +11,7 @@ class TestForegrounds(unittest.TestCase):
         n1 = noise.white_noise((100,fqs.size))
         bl_len_ns = 30.
         dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
-        n1_filt = foregrounds.rough_delay_filter(n1, fqs, bl_len_ns)
+        n1_filt = utils.rough_delay_filter(n1, fqs, bl_len_ns)
         _n1_filt = np.fft.ifft(n1_filt, axis=-1)
         np.testing.assert_array_less(np.mean(np.abs(_n1_filt), axis=0), 
             np.exp(-dlys**2 / (2*bl_len_ns**2)).clip(1e-15,1))
@@ -26,10 +26,10 @@ class TestForegrounds(unittest.TestCase):
         times = lsts / (2*np.pi) * aipy.const.sidereal_day
         n1 = noise.white_noise((lsts.size,fqs.size))
         bl_len_ns = 30.
-        n1_filt = foregrounds.rough_fringe_filter(n1, lsts, fqs, bl_len_ns)
+        n1_filt = utils.rough_fringe_filter(n1, lsts, fqs, bl_len_ns)
         _n1_filt = np.fft.fft(n1_filt, axis=-2)
-        fr_max1 = foregrounds.calc_max_fringe_rate(.1, bl_len_ns)
-        fr_max2 = foregrounds.calc_max_fringe_rate(.2, bl_len_ns)
+        fr_max1 = utils.calc_max_fringe_rate(.1, bl_len_ns)
+        fr_max2 = utils.calc_max_fringe_rate(.2, bl_len_ns)
         fringe_rates = np.fft.fftfreq(times.size, times[1]-times[0])
         inside_filter = np.where(np.abs(fringe_rates) < fr_max1)[0]
         outside_filter = np.where(np.abs(fringe_rates) > fr_max2, 1, 0)

--- a/hera_sim/tests/test_foregrounds.py
+++ b/hera_sim/tests/test_foregrounds.py
@@ -26,7 +26,7 @@ class TestForegrounds(unittest.TestCase):
         times = lsts / (2*np.pi) * aipy.const.sidereal_day
         n1 = noise.white_noise((lsts.size,fqs.size))
         bl_len_ns = 30.
-        n1_filt = utils.rough_fringe_filter(n1, lsts, fqs, bl_len_ns)
+        n1_filt, ff, fr = utils.rough_fringe_filter(n1, lsts, fqs, bl_len_ns)
         _n1_filt = np.fft.fft(n1_filt, axis=-2)
         fr_max1 = utils.calc_max_fringe_rate(.1, bl_len_ns)
         fr_max2 = utils.calc_max_fringe_rate(.2, bl_len_ns)

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -6,13 +6,36 @@ import aipy
 from . import noise
 
 def rough_delay_filter(noise, fqs, bl_len_ns):
+    """
+    A rough high-pass filtering of noise array
+    across frequency.
+
+    Args:
+        noise : 1D or 2D ndarray, filtered along last axis
+        fqs : 1D frequency array, [GHz]
+        bl_len_ns : baseline length, [nanosec]
+
+    Returns:
+        filt_noise : delay-filtered noise
+    """
     dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
     _noise = np.fft.fft(noise)
     dly_filter = np.exp(-dlys**2 / (2*bl_len_ns**2))
     dly_filter.shape = (1,) * (_noise.ndim-1) + (-1,)
-    return np.fft.ifft(_noise * dly_filter)
+    filt_noise = np.fft.ifft(_noise * dly_filter)
+    return filt_noise
 
 def calc_max_fringe_rate(fqs, bl_len_ns):
+    """
+    Calculate the fringe-rate at zenith of
+    a E-W baseline length
+
+    Args:
+        fqs : frequency array [GHz]
+        bl_len_ns : projected East-West baseline length [ns]
+    Returns:
+        fr_max : fringe rate [lambda / sec]
+    """
     bl_wavelen = fqs * bl_len_ns
     fr_max = 2*np.pi/aipy.const.sidereal_day * bl_wavelen
     return fr_max
@@ -20,6 +43,18 @@ def calc_max_fringe_rate(fqs, bl_len_ns):
 def rough_fringe_filter(noise, lsts, fqs, bl_len_ns, fr_width=None):
     """
     Perform a rough fringe rate filter on noise array
+    along second-to-last axis.
+
+    Args:
+        noise : 1D or 2D ndarray, filtered along last axis
+        fqs : 1D frequency array, [GHz]
+        bl_len_ns : baseline length, [nanosec]
+        fr_width : half-width of a Gaussian FR filter in [1/sec]
+            to apply. If None filter is a flat-top FR filter.
+            Can be a float or an array of size fqs.
+
+    Returns:
+        filt_noise : fringe-rate-filtered noise
     """
     times = lsts / (2*np.pi) * aipy.const.sidereal_day
     fringe_rates = np.fft.fftfreq(times.size, times[1]-times[0])
@@ -35,12 +70,13 @@ def rough_fringe_filter(noise, lsts, fqs, bl_len_ns, fr_width=None):
         # use a gaussian centered at max fr
         fng_filter = np.exp(-0.5 * ((fringe_rates-fr_max)/fr_width)**2)
 
-    return np.fft.ifft(_noise * fng_filter, axis=-2)
+    filt_noise = np.fft.ifft(_noise * fng_filter, axis=-2)
+
+    return filt_noise, fng_filter, fringe_rates
     
 def compute_ha(lsts, ra):
     ha = lsts - ra
     ha = np.where(ha > np.pi, ha-2*np.pi, ha)
     ha = np.where(ha < -np.pi, ha+2*np.pi, ha)
     return ha
-
 

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -3,7 +3,7 @@
 import numpy as np
 from scipy.interpolate import RectBivariateSpline
 import aipy
-import noise
+from . import noise
 
 def rough_delay_filter(noise, fqs, bl_len_ns):
     dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -1,0 +1,46 @@
+""" Utility module """
+
+import numpy as np
+from scipy.interpolate import RectBivariateSpline
+import aipy
+import noise
+
+def rough_delay_filter(noise, fqs, bl_len_ns):
+    dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
+    _noise = np.fft.fft(noise)
+    dly_filter = np.exp(-dlys**2 / (2*bl_len_ns**2))
+    dly_filter.shape = (1,) * (_noise.ndim-1) + (-1,)
+    return np.fft.ifft(_noise * dly_filter)
+
+def calc_max_fringe_rate(fqs, bl_len_ns):
+    bl_wavelen = fqs * bl_len_ns
+    fr_max = 2*np.pi/aipy.const.sidereal_day * bl_wavelen
+    return fr_max
+
+def rough_fringe_filter(noise, lsts, fqs, bl_len_ns, fr_width=None):
+    """
+    Perform a rough fringe rate filter on noise array
+    """
+    times = lsts / (2*np.pi) * aipy.const.sidereal_day
+    fringe_rates = np.fft.fftfreq(times.size, times[1]-times[0])
+    fringe_rates.shape = (-1,) + (1,) * (noise.ndim-1)
+    _noise = np.fft.fft(noise, axis=-2)
+    fr_max = calc_max_fringe_rate(fqs, bl_len_ns)
+    fr_max.shape = (1,) * (noise.ndim-1) + (-1,)
+
+    if fr_width is None:
+        # use a top-hat filter with width set by maximum fr
+        fng_filter = np.where(np.abs(fringe_rates) < fr_max, 1., 0)
+    else:
+        # use a gaussian centered at max fr
+        fng_filter = np.exp(-0.5 * ((fringe_rates-fr_max)/fr_width)**2)
+
+    return np.fft.ifft(_noise * fng_filter, axis=-2)
+    
+def compute_ha(lsts, ra):
+    ha = lsts - ra
+    ha = np.where(ha > np.pi, ha-2*np.pi, ha)
+    ha = np.where(ha < -np.pi, ha+2*np.pi, ha)
+    return ha
+
+

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -18,11 +18,11 @@ def rough_delay_filter(noise, fqs, bl_len_ns):
     Returns:
         filt_noise : delay-filtered noise
     """
-    dlys = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
+    delays = np.fft.fftfreq(fqs.size, fqs[1]-fqs[0])
     _noise = np.fft.fft(noise)
-    dly_filter = np.exp(-dlys**2 / (2*bl_len_ns**2))
-    dly_filter.shape = (1,) * (_noise.ndim-1) + (-1,)
-    filt_noise = np.fft.ifft(_noise * dly_filter)
+    delay_filter = np.exp(-delays**2 / (2*bl_len_ns**2))
+    delay_filter.shape = (1,) * (_noise.ndim-1) + (-1,)
+    filt_noise = np.fft.ifft(_noise * delay_filter)
     return filt_noise
 
 def calc_max_fringe_rate(fqs, bl_len_ns):

--- a/hera_sim/vis.py
+++ b/hera_sim/vis.py
@@ -1,5 +1,5 @@
 import numpy as np
-import foregrounds, rfi, noise, sigchain
+from . import foregrounds, rfi, noise, sigchain
 from scipy.interpolate import RectBivariateSpline
 
 DEFAULT_LSTS = np.linspace(0, 2*np.pi, 10000, endpoint=False)


### PR DESCRIPTION
More realistic EoR signals can be added to this module in the future. This is
modeled after the `diffuse_foreground` function in `foregrounds.py`.

This also creates `utils.py` for repo-wide functions, specifically access to fringe-rate filtering
functions. I added the ability in `rough_fringe_filter` to use a gaussian filter, in addition to a top-hat filter.