### PR TITLE
added reflections.py for simulating reflections

### DIFF
--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -5,6 +5,7 @@ import noise
 import rfi
 import sigchain
 import vis
+import reflections
 import version
 #import antpos
 __version__ = version.version

--- a/hera_sim/reflections.py
+++ b/hera_sim/reflections.py
@@ -1,0 +1,82 @@
+"""A module for generating reflections"""
+
+import numpy as np
+import aipy
+
+def auto_reflection(vis, freqs, amp, dly, phs, conj=False):
+    """
+    Insert an auto reflection into vis data. An auto reflection
+    is one that couples an antenna's voltage stream with itself.
+    Examples include cable reflections and dish-to-feed reflections.
+
+    Args:
+        vis : 2D complex ndarray, shape=(Ntimes, Nfreqs)
+        freqs : 1D ndarray, holds frequencies in GHz
+        amp : float, reflection amplitude
+        dly : float, reflection delay [nanosec]
+        phs : float, reflection phase [radian]
+        conj : bool, if True, conjugate reflection coefficient
+
+    Returns:
+        out_vis : contains input vis with the auto reflection
+    """
+    # form reflection coefficient
+    eps = amp * np.exp(2j * np.pi * freqs * dly + 1j * phs)
+    if conj:
+        eps = eps.conj()
+
+    # multiply into data
+    out_vis = vis * (1 + eps)
+
+    return out_vis
+
+
+def cross_reflection(vis, freqs, autocorr, amp, dly, phs, conj=False):
+    """
+    Insert a cross reflection (e.g. crosstalk) into vis data,
+    which is assumed to be a cross correlation visibility.
+    A cross reflection introduces an autocorrelation term into the
+    crosscorrelation at a specific delay with suppressed amplitude.
+
+    Args:
+        vis : 2D complex ndarray, with shape=(Ntimes, Nfreqs)
+        freqs : 1D ndarray, holding frequenices [GHz]
+        autocorr : 2D float ndarray, autocorrelation waterfall
+            matching vis in shape and units
+        amp : float or 1D ndarray, reflection amplitude(s)
+        dly : float or 1D ndarray, reflection delay(s)
+        phs : float or 1D ndarray, reflection phase(s)
+        conj : bool, if True, conjugate reflection coefficient
+
+    Returns:
+        out_vis : 2D complex ndarray, holding input vis data
+            with cross reflections added in.
+    """
+    # generate empty reflection coefficient across freq
+    eps = np.zeros(len(freqs), dtype=np.complex)
+
+    if isinstance(amp, (float, np.float, np.int, int)):
+        amp = [amp]
+    if isinstance(dly, (float, np.float, np.int, int)):
+        dly = [dly]
+    if isinstance(phs, (float, np.float, np.int, int)):
+        phs = [phs]
+
+    # iterate over reflection parameters
+    for a, d, p in zip(amp, dly, phs):
+        eps += a * np.exp(2j * np.pi * freqs * d + 1j * p)
+    if conj:
+        eps = eps.conj()
+
+    # generate reflection term
+    X = eps * autocorr
+
+    # add into vis
+    out_vis = vis + X
+
+    return out_vis
+
+
+
+
+

--- a/hera_sim/reflections.py
+++ b/hera_sim/reflections.py
@@ -8,6 +8,17 @@ def auto_reflection(vis, freqs, amp, dly, phs, conj=False):
     Insert an auto reflection into vis data. An auto reflection
     is one that couples an antenna's voltage stream with itself.
     Examples include cable reflections and dish-to-feed reflections.
+    
+    If v_1 is antenna 1's voltage spectrum, and V_12 is the
+    cross correlation visibility between antenna 1 and 2,
+    then an auto reflection in the visibility can be written as
+
+        V_12 = v_1 (1 + eps_1) v_2^* (1 + eps_2)^*
+
+    where eps_1 is antenna 1's reflection coefficient which
+    can be constructed as
+
+        eps = amp * exp[2j pi dly nu + 1j phs]
 
     Args:
         vis : 2D complex ndarray, shape=(Ntimes, Nfreqs)
@@ -37,6 +48,17 @@ def cross_reflection(vis, freqs, autocorr, amp, dly, phs, conj=False):
     which is assumed to be a cross correlation visibility.
     A cross reflection introduces an autocorrelation term into the
     crosscorrelation at a specific delay with suppressed amplitude.
+
+    If v_1 is antenna 1's voltage spectrum, and V_12 is the 
+    cross-correlation visibility between antenna 1 and 2,
+    then a cross reflection in the visibility can be written as
+
+        V_12 = v_1 (v_2 + eps_12 v_1)^*
+             = v_1 v_2^* + v_1 v_1^* eps_12^*
+
+    where eps_12 is the coupling of antenna 1's voltage into
+    antenna 2's signal chain, and is a standard reflection
+    coefficient as described in auto_reflection().
 
     Args:
         vis : 2D complex ndarray, with shape=(Ntimes, Nfreqs)

--- a/hera_sim/tests/test_reflections.py
+++ b/hera_sim/tests/test_reflections.py
@@ -1,0 +1,78 @@
+import unittest
+from hera_sim import reflections, foregrounds, noise
+import numpy as np
+import aipy
+import nose.tools as nt
+from scipy.signal import windows
+
+np.random.seed(0)
+
+class TestReflections(unittest.TestCase):
+
+    def setUp(self):
+        # setup simulation parameters
+        fqs = np.linspace(.1, .2, 100, endpoint=False)
+        lsts = np.linspace(0, 2*np.pi, 200)
+        times = lsts / (2*np.pi) * aipy.const.sidereal_day
+        Tsky_mdl = noise.HERA_Tsky_mdl['xx']
+        Tsky = Tsky_mdl(lsts, fqs)
+        bl_len_ns = 50.
+        vis = foregrounds.diffuse_foreground(Tsky_mdl, lsts, fqs, bl_len_ns)
+
+        self.freqs = fqs
+        self.lsts = lsts
+        self.Tsky = Tsky
+        self.bl_len_ns = bl_len_ns
+        self.vis = vis
+        self.vfft = np.fft.fft(vis, axis=1)
+        self.dlys = np.fft.fftfreq(len(fqs), d=np.median(np.diff(fqs)))
+
+    def test_auto_reflection(self):
+        # introduce a cable reflection into the autocorrelation
+        outvis = reflections.auto_reflection(self.Tsky, self.freqs, 1e-1, 300, 1)
+        ovfft = np.fft.fft(outvis * windows.blackmanharris(len(self.freqs))[None, :], axis=1)
+
+        # assert reflection is at +300 ns and check its amplitude
+        select = self.dlys > 100
+        nt.assert_almost_equal(self.dlys[select][np.argmax(np.mean(np.abs(ovfft), axis=0)[select])], 300)
+        select = np.argmin(np.abs(self.dlys - 300))
+        nt.assert_true(np.mean(np.abs(ovfft), axis=0)[select] > 900)
+
+        # assert no reflection at -300 ns
+        select = np.argmin(np.abs(self.dlys - -300))
+        nt.assert_true(np.mean(np.abs(ovfft), axis=0)[select] < 1.0)
+
+        # conjugate reflection, and assert it now shows up at -300 ns
+        outvis = reflections.auto_reflection(self.Tsky, self.freqs, 1e-1, 300, 1, conj=True)
+        ovfft = np.fft.fft(outvis * windows.blackmanharris(len(self.freqs))[None, :], axis=1)
+
+        select = self.dlys < -100
+        nt.assert_almost_equal(self.dlys[select][np.argmax(np.mean(np.abs(ovfft), axis=0)[select])], -300)
+        select = np.argmin(np.abs(self.dlys - -300))
+        nt.assert_true(np.mean(np.abs(ovfft), axis=0)[select] > 900)
+
+    def test_cross_reflection(self):
+        # introduce a cross reflection at a single delay
+        outvis = reflections.cross_reflection(self.vis, self.freqs, self.Tsky, 1e-2, 300, 0)
+        ovfft = np.fft.fft(outvis * windows.blackmanharris(len(self.freqs))[None, :], axis=1)
+
+        # take covariance across time and assert delay 300 is highly covariant
+        # compared to neighbors
+        cov = np.cov(ovfft.T)
+        mcov = np.mean(np.abs(cov), axis=0)
+        select = np.argsort(np.abs(self.dlys - 300))[:10]
+        nt.assert_almost_equal(self.dlys[select][np.argmax(mcov[select])], 300.0)
+        # inspect for yourself: plt.matshow(np.log10(np.abs(cov)))
+
+        # conjugate it and assert it shows up at -300
+        outvis = reflections.cross_reflection(self.vis, self.freqs, self.Tsky, 1e-2, 300, 1, conj=True)
+        ovfft = np.fft.fft(outvis * windows.blackmanharris(len(self.freqs))[None, :], axis=1)
+        cov = np.cov(ovfft.T)
+        mcov = np.mean(np.abs(cov), axis=0)
+        select = np.argsort(np.abs(self.dlys - -300))[:10]
+        nt.assert_almost_equal(self.dlys[select][np.argmax(mcov[select])], -300.0)
+
+        # assert its phase stable across time
+        select = np.argmin(np.abs(self.dlys - -300))
+        nt.assert_true(np.isclose(np.angle(ovfft[:, select]), -1, atol=1e-4, rtol=1e-4).all())
+


### PR DESCRIPTION
Adds functions for simulating and inserting cable reflections and feed-to-feed reflections into visibility data. This is different than `hera_cal.reflections.py` which is responsible for reflection modeling and removal.

This is also different than `hera_sim.sigchain.gen_xtalk`, which simulates random, time-independent crosstalk. This module simulates time-dependent feed-to-feed crosstalk.