### PR TITLE
Allow uvdata object

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -17,9 +17,8 @@ When `reporting a bug <https://github.com/HERA-Team/hera_sim/issues>`_ please in
 Documentation improvements
 ==========================
 
-`hera_sim` could always use more documentation, whether as part of the
-official py21cmmc docs, in docstrings, or even on the web in blog posts,
-articles, and such.
+``hera_sim`` could always use more documentation, whether as part of the
+official ``hera_sim`` docs or in docstrings.
 
 Feature requests and feedback
 =============================

--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -8,6 +8,8 @@ from . import vis
 from . import version
 from . import eor
 from . import utils
+from . import simulate
+from .simulate import Simulator
 
 # import antpos
 __version__ = version.version

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -175,6 +175,9 @@ class Simulator:
 
         """
 
+        if data_filename is not None:
+            warnings.warn("`data_filename` is deprecated, please use `data` instead", DeprecationWarning)
+            
         self.data_filename = data_filename
 
         if self.data_filename is None and data is None:


### PR DESCRIPTION
Allows a UVData object to be passed to the ``Simulator``, via the kwarg ``data``. It is envisioned that ``data`` will become the only way to pass in data -- so it accepts both strings and UVData objects. For backwards-compatibility, the ``data_filename`` argument has been left in, but it should be removed in v0.1.0.

Closes #36