### PR TITLE
exposes omega_p in noise modules

### DIFF
--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -13,7 +13,7 @@ from . import noise
 from . import utils
 
 
-def diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=None, bm_poly=noise.HERA_BEAM_POLY,
+def diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=None, omega_p=None,
                        standoff=0.0, delay_filter_type='tophat', delay_filter_normalize=None,
                        fringe_filter_type='tophat', **fringe_filter_kwargs):
     """
@@ -30,9 +30,8 @@ def diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=None, bm_poly=noise.HERA_BEAM
         Tsky_mdl (callable): interpolation object
             an interpolation object that returns the sky temperature as a
             function of (lst, freqs).  Called as Tsky_mdl(lsts, fqs).
-        bm_poly (polynomial): default=noise.HERA_BEAM_POLY
-            a polynomial fit to the solid-angle beam size of the observation
-            as a function of frequency.  Used to convert temperatures to Jy.
+        omega_p (array-like): shape=(NFREQS,) steradians
+            Sky-integral of beam power. Default is to use noise.HERA_BEAM_POLY polynomial fit.
         standoff (float): baseline horizon buffer [ns] for modeling suprahorizon emission
         delay_filter_type (str): type of delay filter to use, see utils.gen_delay_filter
         delay_filter_normalize (float): delay filter normalization, see utils.gen_delay_filter
@@ -45,10 +44,12 @@ def diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=None, bm_poly=noise.HERA_BEAM
     """
     if Tsky_mdl is None:
         raise TypeError("Tsky_mdl is a required parameter of diffuse_foreground")
-        
+    if omega_p is None:
+        omega_p = noise.bm_poly_to_omega_p(fqs)
+
     # generate a Tsky visibility in time and freq space, convert from K to Jy
     Tsky = Tsky_mdl(lsts, fqs)
-    mdl = np.asarray(Tsky * 1e3 / noise.jy2T(fqs, bm_poly=bm_poly), np.complex)
+    mdl = np.asarray(Tsky * 1e3 / noise.jy2T(fqs, omega_p), np.complex)
 
     # If an auto-correlation, return the beam-weighted integrated sky.
     if np.isclose(np.linalg.norm(bl_vec), 0):

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -29,24 +29,44 @@ HERA_BEAM_POLY = np.array([8.07774113e+08, -1.02194430e+09,
                            5.59397878e+08, -1.72970713e+08, 3.30317669e+07, -3.98798031e+06,
                            2.97189690e+05, -1.24980700e+04, 2.27220000e+02])  # See HERA Memo #27
 
+def bm_poly_to_omega_p(fqs, bm_poly=HERA_BEAM_POLY):
+    """
+    Convert polynomial coefficients to beam area.
 
-def jy2T(fqs, bm_poly=HERA_BEAM_POLY):
+    Args:
+        fqs (array-like): shape=(NFREQS,), GHz
+            frequency array
+        bm_poly (polynomial): default=HERA_BEAM_POLY
+            a polynomial fit to sky-integral, solid-angle beam size of
+            observation as a function of frequency.
+
+    Returns:
+        omega_p : (array-like): shape=(NFREQS,), steradian
+            sky-integral of peak-normalized beam power
+    """
+    return np.polyval(bm_poly, fqs)
+
+
+def jy2T(fqs, omega_p=None):
     """
     Return [mK] / [Jy] for a beam size vs. frequency.
 
     Arg:
         fqs (array-like): shape=(NFREQS,), GHz
             the spectral frequencies of the observation to be generated.
-        bm_poly (polynomial): default=HERA_BEAM_POLY
-            a polynomial fit to the solid-angle beam size of the observation
-            as a function of frequency.  Used to convert temperatures to Jy.
+        omega_p (array-like): shape=(NFREQS,) steradians
+            Sky-integral of beam power.
+
     Returns:
         jy_to_mK (array-like): shape=(NFREQS,)
             a frequency-dependent scalar converting Jy to mK for the provided
             beam size.'''
     """
     lam = aipy.const.c / (fqs * 1e9)
-    bm = np.polyval(bm_poly, fqs)
+    if omega_p is None:
+        bm = np.polyval(bm_poly, fqs)
+    else:
+        bm = omega_p
     return 1e-23 * lam ** 2 / (2 * aipy.const.k * bm) * 1e3 # XXX make Kelvin in future
 
 
@@ -89,6 +109,7 @@ def resample_Tsky(fqs, lsts, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):
             the spectral frequency, in GHz, at which Tsky is specified
         index (float): default=-2.5
             the spectral index used to extrapolate Tsky to other frequencies
+
     Returns:
         tsky (array-like): shape=(NTIMES,NFREQS)
             sky temperature vs. time and frequency
@@ -103,7 +124,7 @@ def resample_Tsky(fqs, lsts, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):
 
 # XXX make inttime default=None
 # XXX reorder fqs/lsts
-def sky_noise_jy(Tsky, fqs, lsts, bm_poly=HERA_BEAM_POLY, B=None, inttime=10.7):
+def sky_noise_jy(Tsky, fqs, lsts, omega_p=None, B=None, inttime=10.7):
     """
     Generate Gaussian noise (in Jy units) corresponding to a sky temperature
     model integrated for the specified integration time and bandwidth.
@@ -115,11 +136,10 @@ def sky_noise_jy(Tsky, fqs, lsts, bm_poly=HERA_BEAM_POLY, B=None, inttime=10.7):
             the spectral frequencies of the observation
         lsts (array-like): shape=(NTIMES,), radians
             local sidereal times of the observation
-        bm_poly (polynomial): default=HERA_BEAM_POLY
-            a polynomial fit to the solid-angle beam size of the observation
-            as a function of frequency.  Used to convert temperatures to Jy.
+        omega_p (array-like): shape=(NFREQS,) steradians
+            Sky-integral of beam power.
         B (float): default=None, GHz
-            the bandwidth used to integrate noise.  If not provided,
+            the channel width used to integrate noise.  If not provided,
             defaults to the delta between fqs,
         inttime (float): default=10.7, seconds
             the time used to integrate noise.  If not provided, defaults
@@ -134,13 +154,13 @@ def sky_noise_jy(Tsky, fqs, lsts, bm_poly=HERA_BEAM_POLY, B=None, inttime=10.7):
     if inttime is None:
         inttime = (lsts[1] - lsts[0]) / (2 * np.pi) * aipy.const.sidereal_day
     # XXX fix below when jy2T changed to Jy/K
-    T2jy = 1e3 / jy2T(fqs, bm_poly=bm_poly)  # K to Jy conversion
+    T2jy = 1e3 / jy2T(fqs, omega_p=omega_p)  # K to Jy conversion
     T2jy.shape = (1, -1)
     Vnoise_jy = T2jy * Tsky / np.sqrt(inttime * B_Hz) # see noise_study.py for discussion of why no factor of 2 here
     return white_noise(Vnoise_jy.shape) * Vnoise_jy
 
 
-def thermal_noise(fqs, lsts, Tsky_mdl=None, Trx=0, bm_poly=HERA_BEAM_POLY, inttime=10.7, **kwargs):
+def thermal_noise(fqs, lsts, Tsky_mdl=None, Trx=0, omega_p=None, inttime=10.7, **kwargs):
     """
     Create thermal noise visibilities.
 
@@ -150,14 +170,14 @@ def thermal_noise(fqs, lsts, Tsky_mdl=None, Trx=0, bm_poly=HERA_BEAM_POLY, intti
         Tsky_mdl (callable, optional): a callable model, with signature ``Tsky_mdl(lsts, fqs)``, which returns a 2D
             array of global beam-averaged sky temperatures (in K) as a function of LST and frequency.
         Trx (float, optional): receiver temperature, in K.
-        bm_poly (np.poly1d, optional): a polynomial defining the frequency-dependence of the beam size.
+        omega_p (array-like): shape=(NFREQS,) steradians
+            Sky-integral of beam power.
         inttime (float, optional): the integration time, in sec.
         **kwargs: passed to :func:`resample_Tsky`.
 
     Returns:
         2d array size(lsts, fqs): the thermal visibilities [Jy].
-
     """
     Tsky = resample_Tsky(fqs, lsts, Tsky_mdl=Tsky_mdl, **kwargs)
     Tsky += Trx
-    return sky_noise_jy(Tsky, fqs, lsts, bm_poly=bm_poly, inttime=inttime)
+    return sky_noise_jy(Tsky, fqs, lsts, omega_p=omega_p, inttime=inttime)

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -305,7 +305,7 @@ class Simulator:
 
         Args:
             model (str or callable): either a string name of a model function existing in :mod:`~hera_sim.noise`,
-                or a callable which has the signature ``fnc(lsts, fqs, bl_len_ns, **kwargs)``.
+                or a callable which has the signature ``fnc(lsts, fqs, bl_len_ns, omega_p, **kwargs)``.
             ret_vis (bool, optional): whether to return the visibilities that are being added to to the base
                 data as a new array. Default False.
             add_vis (bool, optional): whether to add the calculated visibilities to the underlying data array.

--- a/hera_sim/tests/test_foregrounds.py
+++ b/hera_sim/tests/test_foregrounds.py
@@ -11,12 +11,14 @@ np.random.seed(0)
 class TestForegrounds(unittest.TestCase):
     def test_diffuse_foreground(self):
         fqs = np.linspace(.1, .2, 100, endpoint=False)
+        omega_p = noise.bm_poly_to_omega_p(fqs)
         lsts = np.linspace(0, 2*np.pi, 1000)
         times = lsts / (2*np.pi) * aipy.const.sidereal_day
         Tsky_mdl = noise.HERA_Tsky_mdl['xx']
         #Tsky = Tsky_mdl(lsts,fqs)
         bl_len_ns = 30.
-        vis = foregrounds.diffuse_foreground(lsts, fqs, [bl_len_ns, 0, 0], Tsky_mdl=Tsky_mdl, delay_filter_type='tophat', fringe_filter_type='tophat')
+        vis = foregrounds.diffuse_foreground(lsts, fqs, [bl_len_ns, 0, 0], Tsky_mdl=Tsky_mdl, delay_filter_type='tophat',
+                                             fringe_filter_type='tophat', omega_p=omega_p)
         self.assertEqual(vis.shape, (lsts.size,fqs.size))
         # XXX check more substantial things
         #import uvtools, pylab as plt
@@ -36,23 +38,24 @@ class TestForegrounds(unittest.TestCase):
 
     def test_diffuse_foreground_orientation(self):
         fqs = np.linspace(.1, .2, 100, endpoint=False)
+        omega_p = noise.bm_poly_to_omega_p(fqs)
         lsts = np.linspace(0, 2 * np.pi, 1000)
         Tsky_mdl = noise.HERA_Tsky_mdl['xx']
 
         bl_vec = (0, 30.0)
-        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='tophat')
+        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='tophat', omega_p=omega_p)
         self.assertEqual(vis.shape, (lsts.size, fqs.size))
 
         # assert foregrounds show up at positive fringe-rates for FFT
         bl_vec = (100.0, 0.0)
-        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='gauss', fr_width=1e-5)
+        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='gauss', fr_width=1e-5, omega_p=omega_p)
         dfft = np.fft.fftshift(np.fft.fft(vis * dspec.gen_window('blackmanharris', len(vis))[:, None], axis=0), axes=0)
         frates = np.fft.fftshift(np.fft.fftfreq(len(lsts), np.diff(lsts)[0]*12*3600/np.pi))
         max_frate = frates[np.argmax(np.abs(dfft[:, 0]))]
         nt.assert_true(max_frate > 0)
 
         bl_vec = (-100.0, 0.0)
-        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='gauss', fr_width=1e-5)
+        vis = foregrounds.diffuse_foreground(lsts, fqs, bl_vec, Tsky_mdl=Tsky_mdl, fringe_filter_type='gauss', fr_width=1e-5, omega_p=omega_p)
         dfft = np.fft.fftshift(np.fft.fft(vis * dspec.gen_window('blackmanharris', len(vis))[:, None], axis=0), axes=0)
         max_frate = frates[np.argmax(np.abs(dfft[:, 0]))]
         nt.assert_true(max_frate < 0)

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -36,10 +36,11 @@ class TestNoise(unittest.TestCase):
     def test_sky_noise_jy(self):
         fqs = np.linspace(0.1, 0.2, 100)
         lsts = np.linspace(0, 2 * np.pi, 200)
+        omp = noise.bm_poly_to_omega_p(fqs)
         tsky = noise.resample_Tsky(fqs, lsts)
-        jy2T = noise.jy2T(fqs) / 1e3
+        jy2T = noise.jy2T(fqs, omega_p=omp) / 1e3
         jy2T.shape = (1, -1)
-        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=10.7)
+        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=10.7, omega_p=omp)
         self.assertEqual(nos_jy.shape, (200, 100))
         np.testing.assert_allclose(np.average(nos_jy, axis=0), 0, atol=0.7)
         scaling = np.average(tsky, axis=0) / jy2T
@@ -47,12 +48,12 @@ class TestNoise(unittest.TestCase):
             np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * 10.7), 1.0, atol=0.1
         )
         np.random.seed(0)
-        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=None)
+        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=None, omega_p=omp)
         np.testing.assert_allclose(
             np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * aipy.const.sidereal_day/200), 1.0, atol=0.1
         )
         np.random.seed(0)
-        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, B=.1, inttime=10.7)
+        nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, B=.1, inttime=10.7, omega_p=omp)
         np.testing.assert_allclose(
             np.std(nos_jy, axis=0) / scaling * np.sqrt(1e8 * 10.7), 1.0, atol=0.1
         )


### PR DESCRIPTION
Exposes `omega_p` for creating noise models, but keeps default behavior of using a pre-computed polynomial fit from `noise.HERA_BEAM_POLY`