### PR TITLE
restore py3 compatibility for checking instance of basestring

### DIFF
--- a/hera_sim/rfi.py
+++ b/hera_sim/rfi.py
@@ -282,6 +282,11 @@ def _listify(x):
 
     Gotten from https://stackoverflow.com/a/1416677/1467820
     """
+    try:
+        basestring
+    except NameError:
+        basestring = (str, bytes)
+
     if isinstance(x, basestring):
         return [x]
     else:


### PR DESCRIPTION
Simple fix for a bug introduced by merging PR #40 with master