### PR TITLE
Move logic for empty_uvdata to pyuvsim.simsetup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,5 @@ docs/tutorials/\.ipynb_checkpoints/
 hera_sim/GIT_INFO
 
 hera_sim/\.ipynb_checkpoints/
+
+\.cache/

--- a/environment.yml
+++ b/environment.yml
@@ -18,8 +18,9 @@ dependencies:
   - pyuvdata
   - scipy
   - pyyaml
-  - future #only for python 2
+  - future # only for python 2
+  - psutil
   - pip:
     - cached-property
-    - pyuvsim
+    - git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
     - git+https://github.com/HERA-Team/uvtools.git

--- a/hera_sim/io.py
+++ b/hera_sim/io.py
@@ -1,209 +1,126 @@
 """
-A module containing routines for interfacing data produced by `hera_sim` with other codes, especially UVData.
+A module containing routines for interfacing data produced by `hera_sim` with other
+codes, especially UVData.
 """
-import itertools
-
 import numpy as np
-import pyuvdata as uv
-from pyuvdata.utils import get_lst_for_time, polstr2num
+from pyuvsim.simsetup import initialize_uvdata_from_keywords
+from pyuvsim.uvsim import init_uvdata_out
+import copy
 
-SEC_PER_SDAY = 86164.1  # sec per sidereal day
-HERA_LOCATION = [5109342.82705015, 2005241.83929272, -3239939.40461961]
-HERA_LAT_LON_ALT = (-0.53619179912885, 0.3739944696510935, 1073.0000000074506)
+HERA_LAT_LON_ALT = (
+    np.degrees(-0.53619179912885),
+    np.degrees(0.3739944696510935),
+    1073.0000000074506
+)
 
 
-def empty_uvdata(nfreq, ntimes, ants, antpairs=None, pols=['xx', ],
-                 time_per_integ=10.7, min_freq=0.1, channel_bw=0.1 / 1024.,
-                 instrument='hera_sim', telescope_location=HERA_LOCATION,
-                 telescope_lat_lon_alt=HERA_LAT_LON_ALT,
-                 object_name='sim_data', start_jd=2458119.5,
-                 vis_units='uncalib'):
-    """
-    Create an empty UVData object with valid metadata and zeroed data arrays with the correct dimensions.
+def empty_uvdata(nfreq, ntimes, ants, **kwargs):
+    """Construct and return a full :class:`pyuvdata.UVData` object, with empty
+    `data_array`.
+
+    This function is merely a thin wrapper around
+    :func:`pyuvsim.simsetup.initialize_uvdata_from_keywords`, providing some defaults
+    aligned with a nominal HERA telescope.
 
     Args:
-        nfreq (int) : number of frequency channels.
-        ntimes (int): number of LST bins.
-        ant (dict): antenna positions.
-            The key should be an integer antenna ID, and the value should be a tuple of (x, y, z) positions in the units
-            required by UVData.antenna_positions (meters, position relative to telescope_location). Example::
+        nfreq (int):
+            The number of frequency channels to include.
+        ntimes (int):
+            The number of times to observe.
+        ants (dict):
+            A dictionary mapping an integer to a three-tuple of ENU co-ordinates for
+            each antenna. These antennas can be down-selected via keywords.
+        **kwargs:
+            All kwargs are passed directly to
+            :func:`pyuvsim.simsetup.initialize_uvdata_from_keywords`. However,
+            some extra defaults are set:
+                | telescope_location: the site of HERA
+                | telescope_name: "hera_sim"
+                | start_freq: 100 MHz
+                | channel_width: 100 MHz / 1024
+                | integration_time: 10.7 sec
+                | start_time: 2458119.5 JD
+                | end_time: start_time + ntimes*integration_time
+                | polarization_array: np.array([-5])
+                | write_files: False
 
-                ants = {0 : (20., 20., 0.)}
-
-        antpairs (list of len-2 tuples): List of baselines as antenna pair tuples, e.g. ``bls = [(1,2), (3,4)]``.
-            All antennas must be in the ants dict.
-        pols (list of str, optional): polarization strings.
-        time_per_integ (float, optional): Time per integration.
-        min_freq (float, optional): minimum frequency of the frequency array [GHz]
-        channel_bw (float, optional): frequency channel bandwidth [GHz].
-        instrument (str, optional): name of the instrument.
-        telescope_location (list of float, optional): location of the telescope, in default UVData coordinate system.
-            Expects a list of length 3.
-        telescope_lat_lon_alt (tuple of float, optional): Latitude, longitude, and altitude of telescope, corresponding
-            to the coordinates in telescope_location. Default: HERA_LAT_LON_ALT.
-        object_name (str, optional): name of UVData object
-        start_jd (float, optional): Julian date of the first time sample in the dataset.
-        vis_units (str, optional): assumed units of the visibility data.
-    
     Returns:
-        :class:`pyuvdata.UVData`: A new UVData object containing valid metadata and blank (zeroed) arrays.
+        A :class:`pyuvdata.UVData` object, unfilled.
+
     """
-    # Generate empty UVData object
-    uvd = uv.UVData()
+    start_time = kwargs.get("start_time", 2458119.5)
+    integration_time = kwargs.get("integration_time", 10.7)
 
-    # Basic time and freq. specs
-    sim_freq = (min_freq + np.arange(nfreq) * channel_bw) * 1e9  # Hz
-    sim_times = start_jd + np.arange(ntimes) * time_per_integ / SEC_PER_SDAY
-    sim_pols = pols
-    lat, lon, alt = telescope_lat_lon_alt
-    sim_lsts = get_lst_for_time(sim_times, lat, lon, alt)
+    uv = initialize_uvdata_from_keywords(
+        antenna_layout_filename=None,  # To keep consistency with old hera_sim empty_uvdata
+        array_layout=ants,
+        telescope_location=list(kwargs.get("telescope_location", HERA_LAT_LON_ALT)),
+        telescope_name=kwargs.get("telescope_name", "hera_sim"),
+        Nfreqs=nfreq,
+        start_freq=kwargs.get("start_freq", 1e8),
+        freq_array=None,  # To keep consistency with old hera_sim empty_uvdata
+        channel_width=kwargs.get("channel_width", 1e8 / 1024.),
+        Ntimes=ntimes,
+        integration_time=integration_time,
+        start_time=start_time,
+        end_time=kwargs.get("end_time", start_time + ntimes * integration_time),
+        time_array=None,  # To keep consistency with old hera_sim empty_uvdata
+        polarizations=kwargs.get("polarizations", ['xx']),
+        polarization_array=kwargs.get("polarization_array", np.array([-5])),
+        write_files=kwargs.get("write_files", False),
+        **kwargs
+    )[0]  # TODO: The 0 index needs to be removed when pyuvsim is fixed.
 
-    # Basic telescope metadata
-    uvd.instrument = instrument
-    uvd.telescope_name = uvd.instrument
-    uvd.telescope_location = np.array(telescope_location)
-    uvd.telescope_lat_lon_alt = telescope_lat_lon_alt
-    uvd.history = "Generated by hera_sim"
-    uvd.object_name = object_name
-    uvd.vis_units = vis_units
-
-    # Fill-in array layout using dish positions
-    nants = len(ants.keys())
-    uvd.antenna_numbers = np.array([int(antid) for antid in ants.keys()],
-                                   dtype=np.int)
-    uvd.antenna_names = [str(antid) for antid in uvd.antenna_numbers]
-    uvd.antenna_positions = np.zeros((nants, 3))
-    uvd.Nants_data = nants
-    uvd.Nants_telescope = nants
-
-    # Populate antenna position table
-    for i, antid in enumerate(ants.keys()):
-        uvd.antenna_positions[i] = np.array(ants[antid])
-
-    # Generate the antpairs if they are not given explicitly.
-    antpairs, ant1, ant2 = _get_antpairs(ants, antpairs)
-
-    defined_ants = ants.keys()
-    ants_not_found = []
-    for _ant in np.unique((ant1, ant2)):
-        if _ant not in defined_ants:
-            ants_not_found.append(_ant)
-    if len(ants_not_found) > 0:
-        raise KeyError(
-            "Baseline list contains antennas that were not "
-            "defined in the 'ants' dict: %s" % ants_not_found
-        )
-
-    # Convert to baseline integers
-    bls = [uvd.antnums_to_baseline(*_antpair) for _antpair in antpairs]
-    bls = np.unique(bls)
-
-    # Convert back to ant1 and ant2 lists
-    ant1, ant2 = list(zip(*[uvd.baseline_to_antnums(_bl) for _bl in bls]))
-
-    # Add frequency and polarization arrays
-    uvd.freq_array = sim_freq.reshape((1, sim_freq.size))
-    uvd.polarization_array = np.array(
-        [polstr2num(_pol) for _pol in sim_pols], dtype=np.int
-    )
-    uvd.channel_width = sim_freq[1] - sim_freq[0]
-    uvd.Nfreqs = sim_freq.size
-    uvd.Nspws = 1
-    uvd.Npols = len(sim_pols)
-
-    # Generate LST array (for each LST: Nbls copy of LST)
-    # and bls array (repeat bls list Ntimes times)
-    bl_arr, lst_arr = np.meshgrid(np.array(bls), sim_lsts)
-    uvd.baseline_array = bl_arr.flatten()
-    uvd.lst_array = lst_arr.flatten()
-
-    # Time array
-    _, time_arr = np.meshgrid(np.array(bls), sim_times)
-    uvd.time_array = time_arr.flatten()
-
-    # Set antenna arrays (same shape as baseline_array)
-    ant1_arr, _ = np.meshgrid(np.array(ant1), sim_lsts)
-    ant2_arr, _ = np.meshgrid(np.array(ant2), sim_lsts)
-    uvd.ant_1_array = ant1_arr.flatten()
-    uvd.ant_2_array = ant2_arr.flatten()
-
-    # Sets UVWs
-    uvd.set_uvws_from_antenna_positions()
-
-    # Populate array lengths
-    uvd.Nbls = len(bls)
-    uvd.Ntimes = sim_lsts.size
-    uvd.Nblts = bl_arr.size
-
-    # Initialise data, flag, and integration arrays
-    uvd.data_array = np.zeros(
-        (uvd.Nblts, uvd.Nspws, uvd.Nfreqs, uvd.Npols), dtype=np.complex64
-    )
-    uvd.flag_array = np.zeros((uvd.Nblts, uvd.Nspws, uvd.Nfreqs, uvd.Npols), dtype=bool)
-    uvd.nsample_array = np.ones(
-        (uvd.Nblts, uvd.Nspws, uvd.Nfreqs, uvd.Npols), dtype=np.float32
-    )
-    uvd.spw_array = np.ones(1, dtype=np.int)
-    uvd.integration_time = time_per_integ * np.ones(uvd.Nblts)  # per bl-time
-
-    uvd.phase_type = 'drift'
-
-    # Check validity and return
-    uvd.check()
-    return uvd
+    init_uvdata_out(uv)
+    return uv
 
 
-def _get_antpairs(ants, antpairs):
-    # Generate antpairs
-    if antpairs is None:
-        # Use all pairs (including auto-correlations)
-        antpairs = [(ant, ant) for ant in ants] + list(itertools.combinations(ants.keys(), 2))
-    elif isinstance(antpairs, str):
-        if antpairs == "cross":
-            # Use all cross-pairs but no autos
-            antpairs = list(itertools.combinations(ants.keys(), 2))
-        elif antpairs == 'autos':
-            antpairs = [(ant, ant) for ant in ants]
-        elif antpairs == "EW":
-            # Use only baselines that are close to EW-oriented (< 10% NS)
-            antpairs = []
-            antnums = list(ants)
+def init_uvdata_out(uv_in, inplace=True):
+    """
+    Initialize an empty uvdata object to fill with simulated data.
 
-            for i, ant1 in enumerate(antnums):
-                pos1 = ants[ant1]
+    NOTE: this is a copy of the function from pyuvsim, but streamlined.
+    Args:
+        uv_in: The input uvdata object.
+               This is usually an incomplete object, containing only metadata.
+        source_list_name: Name of source list file or mock catalog.
+        obs_param_file: Name of observation parameter config file
+        telescope_config_file: Name of telescope config file
+        antenna_location_file: Name of antenna location file
+    """
+    if not inplace:
+        uv_obj = copy.deepcopy(uv_in)
+    else:
+        uv_obj = uv_in
 
-                for ant2 in antnums[i:]:
-                    pos2 = ants[ant2]
+    uv_obj.set_drift()
+    uv_obj.vis_units = 'Jy'
 
-                    if ant1 == ant2 or np.abs(pos1[1] - pos2[1]) / np.abs(pos1[0] - pos2[0]) < 0.1:
-                        antpairs += [(ant1, ant2)]
+    uv_obj.instrument = uv_obj.telescope_name
+    uv_obj.set_lsts_from_time_array()
+    uv_obj.spw_array = np.array([0])
+    if uv_obj.Nfreqs == 1:
+        uv_obj.channel_width = 1.  # Hz
+    else:
+        uv_obj.channel_width = np.diff(uv_obj.freq_array[0])[0]
+    uv_obj.set_uvws_from_antenna_positions()
+    if uv_obj.Ntimes == 1:
+        uv_obj.integration_time = np.ones_like(uv_obj.time_array, dtype=np.float64)  # Second
+    else:
+        # Note: currently only support a constant spacing of times
+        uv_obj.integration_time = (np.ones_like(uv_obj.time_array, dtype=np.float64)
+                                   * np.diff(np.unique(uv_obj.time_array))[0] * (24. * 60**2))  # Seconds
 
-        elif antpairs == 'redundant':
-            # Use only a single baseline from all redundant "types", with redundancy within
-            # 0.1m ?
-            antpairs = []
-            baseline_types = {}
-            antnums = list(ants)
-            for i, ant1 in enumerate(antnums):
-                pos1 = ants[ant1]
+    # Clear existing data, if any
+    uv_obj.data_array = np.zeros((uv_obj.Nblts, uv_obj.Nspws, uv_obj.Nfreqs, uv_obj.Npols), dtype=np.complex)
+    uv_obj.flag_array = np.zeros((uv_obj.Nblts, uv_obj.Nspws, uv_obj.Nfreqs, uv_obj.Npols), dtype=bool)
+    uv_obj.nsample_array = np.ones_like(uv_obj.data_array, dtype=float)
 
-                for ant2 in antnums[i:]:
-                    pos2 = ants[ant2]
+    uv_obj.extra_keywords = {}
 
-                    if ant1 == ant2:
-                        antpairs += [(ant1, ant2)]
-                    else:
-                        id = str(list(np.round([p1 - p2 for p1, p2 in zip(pos1, pos2)], decimals=1)))
-                        if id not in baseline_types:
-                            antpairs += [(ant1, ant2)]
-                            baseline_types[id] = (ant1, ant2)
-        else:
-            raise ValueError("if antpairs is a string, it must be one of 'cross', 'autos', 'EW' or 'redundant'.")
+    # TODO: this needs to be fixed in the original metadata setter
+    uv_obj.telescope_location = list(uv_obj.telescope_location)
+    uv_obj.antenna_names = uv_obj.antenna_numbers.astype('str')
+    uv_obj.check()
 
-    # Check that baselines only involve antennas that have been defined
-    try:
-        ant1, ant2 = zip(*antpairs)
-    except (TypeError, ValueError):
-        raise TypeError("antpairs must be a list of 2-tuples")
-
-    return antpairs, ant1, ant2
+    return uv_obj

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -74,7 +74,7 @@ class _model(object):
                 warnings.warn("You are adding absolute visibilities _after_ determining visibilities that should " +
                               "depend on these. Please re-consider.")
 
-            if "model" in inspect.getargspec(func)[0]:
+            if "model" in inspect.getargspec(func)[0]: # TODO: needs to be updated for python 3
                 # Cases where there is a choice of model
                 model = args[0] if args else kwargs.pop("model")
 
@@ -215,6 +215,11 @@ class Simulator:
             elif self.data is not None:
                 self.data = data
 
+        # Assume the phase type is drift unless otherwise specified.
+        if self.data.phase_type == "unknown":
+            self.data.set_drift()
+
+        self.data.baseline_array
         # Check if the created/read data is compatible with the assumptions of
         # this class.
         self._check_compatibility()
@@ -349,12 +354,11 @@ class Simulator:
         for ant1, ant2, pol, blt_ind, pol_ind in self._iterate_antpair_pols():
             lsts = self.data.lst_array[blt_ind]
 
-            # RFI added in-place
-            model(
+            # RFI added in-place (giving rfi= does not seem to work here)
+            self.data.data_array[blt_ind, 0, :, 0] += model(
                 lsts=lsts,
                 # Axis 0 is spectral windows, of which at this point there are always 1.
                 fqs=self.data.freq_array[0] * 1e-9,
-                rfi=self.data.data_array[blt_ind, 0, :, 0],
                 **kwargs
             )
 

--- a/hera_sim/tests/test_io.py
+++ b/hera_sim/tests/test_io.py
@@ -1,11 +1,10 @@
 import unittest
+
 from hera_sim import io
-import numpy as np
 
 
 class TestIO(unittest.TestCase):
     def test_empty_uvdata(self):
-
         # Make sure that empty_uvdata() can produce a UVData object
         nfreqs = 150
         ntimes = 20
@@ -19,58 +18,8 @@ class TestIO(unittest.TestCase):
 
         # Check that duplicate baselines get filtered out
         uvd = io.empty_uvdata(nfreqs, ntimes, ants=ants, antpairs=antpairs2)
-        self.assertEqual( uvd.data_array.shape, 
-                          (len(antpairs1)*ntimes, 1, nfreqs, 1) )
-
-    # def test_cross_antpairs(self):
-    #     ants = {
-    #         0: (1., 2., 3.),
-    #         1: (3., 4., 5.),
-    #         2: (5. ,6. ,7.)
-    #     }
-    #
-    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "cross")
-    #
-    #     self.assertEqual(antpairs, [(0, 1), (0, 2), (1, 2)])
-    #     self.assertEqual(ant1, (0, 0, 1))
-    #     self.assertEqual(ant2, (1, 2, 2))
-
-    # def test_auto_antpairs(self):
-    #     ants = {
-    #         0: (1., 2., 3.),
-    #         1: (3., 4., 5.),
-    #         2: (5. ,6. ,7.)
-    #     }
-    #
-    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "autos")
-    #
-    #     self.assertEqual(antpairs, [(0,0), (1,1), (2, 2)])
-    #     self.assertEqual(ant1, (0, 1, 2))
-    #     self.assertEqual(ant2, (0, 1, 2))
-
-    # def test_EW_antpairs(self):
-    #     ants = {
-    #         0: (1., 2., 3.),
-    #         1: (3., 2., 3.),
-    #         2: (5. ,6. ,7.)
-    #     }
-    #
-    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "EW")
-    #
-    #     self.assertEqual(set(antpairs), {(0, 0), (1,1), (2,2), (0,1)})
-
-    # def test_bad_antpairs(self):
-    #     # Make sure that empty_uvdata() can produce a UVData object
-    #     nfreqs = 150
-    #     ntimes = 20
-    #     ants = {
-    #         0: (1., 2., 3.),
-    #         1: (3., 4., 5.)
-    #     }
-    #     antpairs1 = [(0, 1), (1, 0), (1, 1), 1]
-    #
-    #     with self.assertRaises(TypeError):
-    #         uvd = io.empty_uvdata(nfreqs, ntimes, ants=ants, antpairs=antpairs1)
+        self.assertEqual(uvd.data_array.shape,
+                         (len(antpairs1) * ntimes, 1, nfreqs, 1))
 
 
 if __name__ == '__main__':

--- a/hera_sim/tests/test_io.py
+++ b/hera_sim/tests/test_io.py
@@ -22,66 +22,55 @@ class TestIO(unittest.TestCase):
         self.assertEqual( uvd.data_array.shape, 
                           (len(antpairs1)*ntimes, 1, nfreqs, 1) )
 
-    def test_cross_antpairs(self):
-        ants = {
-            0: (1., 2., 3.),
-            1: (3., 4., 5.),
-            2: (5. ,6. ,7.)
-        }
+    # def test_cross_antpairs(self):
+    #     ants = {
+    #         0: (1., 2., 3.),
+    #         1: (3., 4., 5.),
+    #         2: (5. ,6. ,7.)
+    #     }
+    #
+    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "cross")
+    #
+    #     self.assertEqual(antpairs, [(0, 1), (0, 2), (1, 2)])
+    #     self.assertEqual(ant1, (0, 0, 1))
+    #     self.assertEqual(ant2, (1, 2, 2))
 
-        antpairs, ant1, ant2 = io._get_antpairs(ants, "cross")
+    # def test_auto_antpairs(self):
+    #     ants = {
+    #         0: (1., 2., 3.),
+    #         1: (3., 4., 5.),
+    #         2: (5. ,6. ,7.)
+    #     }
+    #
+    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "autos")
+    #
+    #     self.assertEqual(antpairs, [(0,0), (1,1), (2, 2)])
+    #     self.assertEqual(ant1, (0, 1, 2))
+    #     self.assertEqual(ant2, (0, 1, 2))
 
-        self.assertEqual(antpairs, [(0, 1), (0, 2), (1, 2)])
-        self.assertEqual(ant1, (0, 0, 1))
-        self.assertEqual(ant2, (1, 2, 2))
+    # def test_EW_antpairs(self):
+    #     ants = {
+    #         0: (1., 2., 3.),
+    #         1: (3., 2., 3.),
+    #         2: (5. ,6. ,7.)
+    #     }
+    #
+    #     antpairs, ant1, ant2 = io._get_antpairs(ants, "EW")
+    #
+    #     self.assertEqual(set(antpairs), {(0, 0), (1,1), (2,2), (0,1)})
 
-    def test_auto_antpairs(self):
-        ants = {
-            0: (1., 2., 3.),
-            1: (3., 4., 5.),
-            2: (5. ,6. ,7.)
-        }
-
-        antpairs, ant1, ant2 = io._get_antpairs(ants, "autos")
-
-        self.assertEqual(antpairs, [(0,0), (1,1), (2, 2)])
-        self.assertEqual(ant1, (0, 1, 2))
-        self.assertEqual(ant2, (0, 1, 2))
-
-    def test_EW_antpairs(self):
-        ants = {
-            0: (1., 2., 3.),
-            1: (3., 2., 3.),
-            2: (5. ,6. ,7.)
-        }
-
-        antpairs, ant1, ant2 = io._get_antpairs(ants, "EW")
-
-        self.assertEqual(set(antpairs), {(0, 0), (1,1), (2,2), (0,1)})
-
-    def test_redundant_antpairs(self):
-        ants = {
-            0: (1., 2., 3.),
-            1: (2., 3., 3.),
-            2: (3., 4., 3.)
-        }
-
-        antpairs, ant1, ant2 = io._get_antpairs(ants, "redundant")
-
-        self.assertEqual(set(antpairs), {(0, 0), (1,1), (2,2 ), (0,1), (0, 2)})
-
-    def test_bad_antpairs(self):
-        # Make sure that empty_uvdata() can produce a UVData object
-        nfreqs = 150
-        ntimes = 20
-        ants = {
-            0: (1., 2., 3.),
-            1: (3., 4., 5.)
-        }
-        antpairs1 = [(0, 1), (1, 0), (1, 1), 1]
-
-        with self.assertRaises(TypeError):
-            uvd = io.empty_uvdata(nfreqs, ntimes, ants=ants, antpairs=antpairs1)
+    # def test_bad_antpairs(self):
+    #     # Make sure that empty_uvdata() can produce a UVData object
+    #     nfreqs = 150
+    #     ntimes = 20
+    #     ants = {
+    #         0: (1., 2., 3.),
+    #         1: (3., 4., 5.)
+    #     }
+    #     antpairs1 = [(0, 1), (1, 0), (1, 1), 1]
+    #
+    #     with self.assertRaises(TypeError):
+    #         uvd = io.empty_uvdata(nfreqs, ntimes, ants=ants, antpairs=antpairs1)
 
 
 if __name__ == '__main__':

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -35,13 +35,13 @@ class TestNoise(unittest.TestCase):
 
     def test_sky_noise_jy(self):
         fqs = np.linspace(0.1, 0.2, 100)
-        lsts = np.linspace(0, 2 * np.pi, 300)
+        lsts = np.linspace(0, 2 * np.pi, 500)
         omp = noise.bm_poly_to_omega_p(fqs)
         tsky = noise.resample_Tsky(fqs, lsts)
         jy2T = noise.jy2T(fqs, omega_p=omp) / 1e3
         jy2T.shape = (1, -1)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=10.7, omega_p=omp)
-        self.assertEqual(nos_jy.shape, (300, 100))
+        self.assertEqual(nos_jy.shape, (500, 100))
         np.testing.assert_allclose(np.average(nos_jy, axis=0), 0, atol=0.7)
         scaling = np.average(tsky, axis=0) / jy2T
         np.testing.assert_allclose(

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -50,7 +50,7 @@ class TestNoise(unittest.TestCase):
         np.random.seed(0)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=None, omega_p=omp)
         np.testing.assert_allclose(
-            np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * aipy.const.sidereal_day/300), 1.0, atol=0.1
+            np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * aipy.const.sidereal_day/500), 1.0, atol=0.1
         )
         np.random.seed(0)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, B=.1, inttime=10.7, omega_p=omp)

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -35,13 +35,13 @@ class TestNoise(unittest.TestCase):
 
     def test_sky_noise_jy(self):
         fqs = np.linspace(0.1, 0.2, 100)
-        lsts = np.linspace(0, 2 * np.pi, 200)
+        lsts = np.linspace(0, 2 * np.pi, 300)
         omp = noise.bm_poly_to_omega_p(fqs)
         tsky = noise.resample_Tsky(fqs, lsts)
         jy2T = noise.jy2T(fqs, omega_p=omp) / 1e3
         jy2T.shape = (1, -1)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=10.7, omega_p=omp)
-        self.assertEqual(nos_jy.shape, (200, 100))
+        self.assertEqual(nos_jy.shape, (300, 100))
         np.testing.assert_allclose(np.average(nos_jy, axis=0), 0, atol=0.7)
         scaling = np.average(tsky, axis=0) / jy2T
         np.testing.assert_allclose(
@@ -50,7 +50,7 @@ class TestNoise(unittest.TestCase):
         np.random.seed(0)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, inttime=None, omega_p=omp)
         np.testing.assert_allclose(
-            np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * aipy.const.sidereal_day/200), 1.0, atol=0.1
+            np.std(nos_jy, axis=0) / scaling * np.sqrt(1e6 * aipy.const.sidereal_day/300), 1.0, atol=0.1
         )
         np.random.seed(0)
         nos_jy = noise.sky_noise_jy(tsky, fqs, lsts, B=.1, inttime=10.7, omega_p=omp)

--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup_args = {
         'mpi4py',   # this is a dependency of pyuvsim which currently is not automatically installed. Remove when possible.
         'pyuvsim',
         'pyuvdata',
-        'aipy'
+        'aipy>=3.0.0rc2'
     ],
     "version": version.version,
     "package_data": {"hera_sim": data_files},


### PR DESCRIPTION
This PR seeks to simplify the `io.empty_uvdata` function so that it basically just uses `pyuvsim`. 

I have checked that all tests work (some tests required removal, since there is now no function for calculating antpairs, and others required fixing). 

I think more can be done to simplify this. It seems to me that `pyuvsim` (or even `pyuvdata`!) should have its own function that does the job of `init_uvdata_out` without all the extra filenames etc., and that this should be callable from within the pyuvsim function. This would remove an extra function here.

Furthermore, it seems that the `initialize_uvdata_from_keywords` sets up the uvdata object with a tuple for the `telescope_location`, which fails the `check()`. Converting to a list fixes it. This is done in this PR, but should be in `pyuvsim`.

Also along these lines, it seems that the `antenna_names` aren't passed through properly, and they have to be set manually. 

Finally, the `polarization_array` is hard-coded to be `[-5, -6, -7, -8]` in `pyuvsim`, which I don't think is a good idea (but I might be wrong here).