### PR TITLE
Updated io.empty_uvdata

### DIFF
--- a/hera_sim/io.py
+++ b/hera_sim/io.py
@@ -69,4 +69,7 @@ def empty_uvdata(nfreq, ntimes, ants, **kwargs):
         **kwargs
     )
 
+    # make sure that the ordering of antpairpol tuples is consistent with abscal assumption
+    uv.conjugate_bls(convention='ant1<ant2')
+
     return uv

--- a/hera_sim/tests/test_io.py
+++ b/hera_sim/tests/test_io.py
@@ -1,4 +1,5 @@
 import unittest
+import numpy as np
 
 from hera_sim import io
 
@@ -21,6 +22,13 @@ class TestIO(unittest.TestCase):
         self.assertEqual(uvd.data_array.shape,
                          (len(antpairs1) * ntimes, 1, nfreqs, 1))
 
+    def test_antpair_order(self):
+        nfreqs = 10
+        ntimes = 10
+        ants = {j: tuple(np.random.rand(3)) for j in range(10)}
+        uvd = io.empty_uvdata(nfreqs, ntimes, ants=ants)
+        for ant1, ant2 in uvd.get_antpairs():
+            self.assertLessEqual(ant1,ant2)
 
 if __name__ == '__main__':
     unittest.main()

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -130,7 +130,10 @@ def test_other_components():
     sim.add_xtalk('gen_cross_coupling_xtalk', bls=[(0, 1, 'xx')])
     sim.add_sigchain_reflections(ants=[0])
 
-    assert np.all(np.isclose(sim.data.data_array,  0))
+    assert not np.all(np.isclose(sim.data.data_array,  0))
+    assert np.all(np.isclose(sim.data.get_data(0,0), 0))
+
+    sim = create_sim()
 
     sim.add_rfi("rfi_stations")
 


### PR DESCRIPTION
Added a line of code to ensure that the antenna pair ordering is consistent with what is assumed by `hera_cal.abscal` methods. This PR addresses issue #56.