### PR TITLE
Improve polarization string handling in sim_red_data

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -26,3 +26,4 @@ dependencies:
     - cached-property
     - git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
     - git+https://github.com/HERA-Team/uvtools.git
+    - git+https://github.com/HERA-Team/hera_cal.git

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -1,5 +1,6 @@
 import unittest
 from hera_sim import vis
+from hera_sim.antpos import linear_array
 import numpy as np
 
 np.random.seed(0)
@@ -98,45 +99,24 @@ class TestSimRedData(unittest.TestCase):
 
     def test_sim_red_data(self):
         # Test that redundant baselines are redundant up to the gains in single pol mode
-        #antpos = build_linear_array(5)
-        #reds = om.get_reds(antpos, pols=['xx'], pol_mode='1pol')
-        # Hard code redundancies to eliminate dependence on hera_cal
-        reds = [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx')], 
-                [(0, 2, 'xx'), (1, 3, 'xx'), (2, 4, 'xx')],
-                [(0, 3, 'xx'), (1, 4, 'xx')],
-                [(0, 4, 'xx')]]
+        from hera_cal import redcal as om
+        antpos = linear_array(5)
+        reds = om.get_reds(antpos, pols=['nn'], pol_mode='1pol')
         gains, true_vis, data = vis.sim_red_data(reds)
         assert len(gains) == 5
         assert len(data) == 10
         for bls in reds:
             bl0 = bls[0]
             ai, aj, pol = bl0
-            ans0 = data[bl0] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jxx')].conj())
+            ans0 = data[bl0] / (gains[(ai, 'Jnn')] * gains[(aj, 'Jnn')].conj())
             for bl in bls[1:]:
                 ai, aj, pol = bl
-                ans = data[bl] / (gains[(ai, 'Jxx')] * gains[(aj, 'Jxx')].conj())
+                ans = data[bl] / (gains[(ai, 'Jnn')] * gains[(aj, 'Jnn')].conj())
                 # compare calibrated visibilities knowing the input gains
                 np.testing.assert_almost_equal(ans0, ans, decimal=7)
 
         # Test that redundant baselines are redundant up to the gains in 4-pol mode
-        #reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yx'], pol_mode='4pol')
-        # Hard code redundancies to eliminate dependence on hera_cal
-        reds = [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx')],
-                [(0, 2, 'xx'), (1, 3, 'xx'), (2, 4, 'xx')],
-                [(0, 3, 'xx'), (1, 4, 'xx')],
-                [(0, 4, 'xx')],
-                [(0, 1, 'yy'), (1, 2, 'yy'), (2, 3, 'yy'), (3, 4, 'yy')],
-                [(0, 2, 'yy'), (1, 3, 'yy'), (2, 4, 'yy')],
-                [(0, 3, 'yy'), (1, 4, 'yy')],
-                [(0, 4, 'yy')],
-                [(0, 1, 'xy'), (1, 2, 'xy'), (2, 3, 'xy'), (3, 4, 'xy')],
-                [(0, 2, 'xy'), (1, 3, 'xy'), (2, 4, 'xy')],
-                [(0, 3, 'xy'), (1, 4, 'xy')],
-                [(0, 4, 'xy')],
-                [(0, 1, 'yx'), (1, 2, 'yx'), (2, 3, 'yx'), (3, 4, 'yx')],
-                [(0, 2, 'yx'), (1, 3, 'yx'), (2, 4, 'yx')],
-                [(0, 3, 'yx'), (1, 4, 'yx')],
-                [(0, 4, 'yx')]]
+        reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yx'], pol_mode='4pol')
         gains, true_vis, data = vis.sim_red_data(reds)
         assert len(gains) == 2 * (5)
         assert len(data) == 4 * (10)
@@ -160,32 +140,7 @@ class TestSimRedData(unittest.TestCase):
                 np.testing.assert_almost_equal(ans0yy, ans_yy, decimal=7)
 
         # Test that redundant baselines are redundant up to the gains in 4-pol minV mode (where Vxy = Vyx)
-        #reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yX'], pol_mode='4pol_minV')
-        # Hard code redundancies to eliminate dependence on hera_cal
-        reds = [[(0, 1, 'xx'), (1, 2, 'xx'), (2, 3, 'xx'), (3, 4, 'xx')],
-                [(0, 2, 'xx'), (1, 3, 'xx'), (2, 4, 'xx')],
-                [(0, 3, 'xx'), (1, 4, 'xx')],
-                [(0, 4, 'xx')],
-                [(0, 1, 'yy'), (1, 2, 'yy'), (2, 3, 'yy'), (3, 4, 'yy')],
-                [(0, 2, 'yy'), (1, 3, 'yy'), (2, 4, 'yy')],
-                [(0, 3, 'yy'), (1, 4, 'yy')],
-                [(0, 4, 'yy')],
-                [(0, 1, 'xy'),
-                 (1, 2, 'xy'),
-                 (2, 3, 'xy'),
-                 (3, 4, 'xy'),
-                 (0, 1, 'yx'),
-                 (1, 2, 'yx'),
-                 (2, 3, 'yx'),
-                 (3, 4, 'yx')],
-                [(0, 2, 'xy'),
-                 (1, 3, 'xy'),
-                 (2, 4, 'xy'),
-                 (0, 2, 'yx'),
-                 (1, 3, 'yx'),
-                 (2, 4, 'yx')],
-                [(0, 3, 'xy'), (1, 4, 'xy'), (0, 3, 'yx'), (1, 4, 'yx')],
-                [(0, 4, 'xy'), (0, 4, 'yx')]]
+        reds = om.get_reds(antpos, pols=['xx', 'yy', 'xy', 'yX'], pol_mode='4pol_minV')
         gains, true_vis, data = vis.sim_red_data(reds)
         assert len(gains) == 2 * (5)
         assert len(data) == 4 * (10)

--- a/hera_sim/vis.py
+++ b/hera_sim/vis.py
@@ -181,10 +181,9 @@ def sim_red_data(reds, gains=None, shape=(10, 10), gain_scatter=0.1):
         dict: true underlying visibilities in the {(ind1,ind2,pol): np.array} format
         dict: simulated visibilities in the {(ind1,ind2,pol): np.array} format
     """
+    from hera_cal.utils import split_bl
     data, true_vis = {}, {}
-    ants = sorted(list(set([ant for bls in reds for bl in bls for ant in 
-                            [(bl[0], jnum2str(jstr2num(bl[2][0]))), 
-                             (bl[1], jnum2str(jstr2num(bl[2][1])))]])))
+    ants = sorted(list(set([ant for bls in reds for bl in bls for ant in split_bl(bl)])))
     if gains is None:
         gains = {}
     else:
@@ -194,7 +193,6 @@ def sim_red_data(reds, gains=None, shape=(10, 10), gain_scatter=0.1):
                       np.ones(shape, dtype=np.complex))
     for bls in reds:
         true_vis[bls[0]] = noise.white_noise(shape)
-        for (i, j, pol) in bls:
-            data[(i, j, pol)] = (true_vis[bls[0]] * gains[(i, jnum2str(jstr2num(pol[0])))] * \
-                                 gains[(j, jnum2str(jstr2num(pol[1])))].conj())
+        for bl in bls:
+            data[bl] = true_vis[bls[0]] * gains[split_bl(bl)[0]] * gains[split_bl(bl)[1]].conj()
     return gains, true_vis, data


### PR DESCRIPTION
Right now, sim_red_data infers antenna polarization (for gains) from visibility polarizations (from reds). This doesn't work for `'nn'` or `'ee'` style polarizations, because x_orientation isn't provided. However, hera_cal (https://github.com/HERA-Team/hera_cal/pull/553) and pyuvdata (https://github.com/RadioAstronomySoftwareGroup/pyuvdata/pull/580) now use the new style.

Now, the function uses hera_cal's ability to gracefully handle this kind of polarization string without knowing x_orientation---all it needs to do is figure out whether it's x/y or n/e. 

The tests and testing environment has been updated accordingly.