### PR TITLE
Makes repo pip-installable

### DIFF
--- a/hera_sim/version.py
+++ b/hera_sim/version.py
@@ -6,7 +6,7 @@ from __future__ import absolute_import
 try:
     from future import standard_library
 except ImportError:
-    from pip._internal import main as pip
+    from pip._internal.main import main as pip
     pip(['install', '--user', 'future'])
     from future import standard_library
 

--- a/hera_sim/version.py
+++ b/hera_sim/version.py
@@ -3,12 +3,7 @@ from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
 
-try:
-    from future import standard_library
-except ImportError:
-    from pip._internal.main import main as pip
-    pip(['install', '--user', 'future'])
-    from future import standard_library
+from future import standard_library
 
 standard_library.install_aliases()
 from builtins import *

--- a/hera_sim/version.py
+++ b/hera_sim/version.py
@@ -2,7 +2,14 @@ from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import division
 from __future__ import absolute_import
-from future import standard_library
+
+try:
+    from future import standard_library
+except ImportError:
+    from pip._internal import main as pip
+    pip(['install', '--user', 'future'])
+    from future import standard_library
+
 standard_library.install_aliases()
 from builtins import *
 from builtins import str

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[build-system]
+requires = ["setuptools>=30.3.0", "wheel", 'numpy>=1.14', 'pip', 'future']
+
 [tool.black]
 line-length = 88
 py36 = false

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,7 @@ setup_args = {
         'pyuvdata',
         'aipy>=3.0',
         'click',
-        'astropy-healpix' # pyuvsim depenency not automatically installed,
+        'astropy-healpix', # pyuvsim depenency not automatically installed,
         "future"
     ],
     "extras_require" : {

--- a/setup.py
+++ b/setup.py
@@ -57,7 +57,8 @@ setup_args = {
         'pyuvdata',
         'aipy>=3.0',
         'click',
-        'astropy-healpix' # pyuvsim depenency not automatically installed
+        'astropy-healpix' # pyuvsim depenency not automatically installed,
+        "future"
     ],
     "extras_require" : {
         "bda" : "bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging"
@@ -68,10 +69,6 @@ setup_args = {
     "entry_points": {"console_scripts": ["hera_sim = hera_sim.cli:main"]},
 }
 
-
-# If on Python 2, we also need the "future" module
-if sys.version.startswith("2"):
-    setup_args['install_requires'].append("future")
 
 if __name__ == "__main__":
     setup(*(), **setup_args)


### PR DESCRIPTION
closes #75 
updates the pyproject.toml to include packages needed for building of the repo. also renames pyproject.toml which had a leading `.`.

I have verified I can install this repo from a blank environment in python 3.
python 2 has _still_ requires `numpy` to be installed to build `aipy`. Oddly the `pyproject.toml` doesn't enforce `numpy` installed in python2. I'm not super worried since python 2 support is dropping soon.