### PR TITLE
Fix output shape of resample_Tsky with callable input

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -25,6 +25,7 @@ dependencies:
   - pip:
     - cached-property
     - git+https://github.com/RadioAstronomySoftwareGroup/pyuvsim.git
+    - git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky.git
     - git+https://github.com/RadioAstronomySoftwareGroup/pyuvdata.git
     - git+https://github.com/HERA-Team/uvtools.git
     - git+https://github.com/rasg-affiliates/healvis

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -115,11 +115,15 @@ def resample_Tsky(fqs, lsts, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):
         tsky = Tsky_mdl(lsts, fqs)  # support an interpolation object
 
         if tsky.shape != (len(lsts), len(fqs)):
-            warnings.warn(
-                "Tsky_mdl should be a callable that takes (lsts, fqs) and returns an"
-                "array with shape (nlsts, nfqs). Note that interp2d objects do"
-                "*not* return this shape! Transposing array...")
-            tsky = tsky.T
+            msg = ("Tsky_mdl should be a callable that takes (lsts, fqs) and returns an"
+                    "array with shape (nlsts, nfqs). Note that interp2d objects do"
+                    "*not* return this shape! Transposing array...")
+
+            if tsky.shape == (len(fqs), len(lsts)):
+                warnings.warn(msg)
+                tsky = tsky.T
+            else:
+                raise ValueError(msg)
 
     else:
         tsky = Tsky * (fqs / mfreq) ** index  # default to a scalar

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -112,7 +112,15 @@ def resample_Tsky(fqs, lsts, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):
             sky temperature vs. time and frequency
     """
     if Tsky_mdl is not None:
-        tsky = Tsky_mdl(lsts, fqs).T  # support an interpolation object
+        tsky = Tsky_mdl(lsts, fqs)  # support an interpolation object
+
+        if tsky.shape != (len(lsts), len(fqs)):
+            warnings.warn(
+                "Tsky_mdl should be a callable that takes (lsts, fqs) and returns an"
+                "array with shape (nlsts, nfqs). Note that interp2d objects do"
+                "*not* return this shape! Transposing array...")
+            tsky = tsky.T
+
     else:
         tsky = Tsky * (fqs / mfreq) ** index  # default to a scalar
         tsky = np.resize(tsky, (lsts.size, fqs.size))

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -112,7 +112,7 @@ def resample_Tsky(fqs, lsts, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):
             sky temperature vs. time and frequency
     """
     if Tsky_mdl is not None:
-        tsky = Tsky_mdl(lsts, fqs)  # support an interpolation object
+        tsky = Tsky_mdl(lsts, fqs).T  # support an interpolation object
     else:
         tsky = Tsky * (fqs / mfreq) ** index  # default to a scalar
         tsky = np.resize(tsky, (lsts.size, fqs.size))

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -24,14 +24,11 @@ class TestNoise(unittest.TestCase):
         self.assertEqual(tsky.shape, (200, 100))
         self.assertTrue(np.all(tsky[0] == tsky[1]))
         self.assertFalse(np.all(tsky[:, 0] == tsky[:, 1]))
-        # import uvtools, pylab as plt
-        # uvtools.plot.waterfall(tsky); plt.show()
+
         tsky = noise.resample_Tsky(fqs, lsts, Tsky_mdl=noise.HERA_Tsky_mdl["xx"])
         self.assertEqual(tsky.shape, (200, 100))
         self.assertFalse(np.all(tsky[0] == tsky[1]))
         self.assertFalse(np.all(tsky[:, 0] == tsky[:, 1]))
-        # import uvtools, pylab as plt
-        # uvtools.plot.waterfall(tsky); plt.show()
 
     def test_sky_noise_jy(self):
         fqs = np.linspace(0.1, 0.2, 100)


### PR DESCRIPTION
This fixes the shape of the output of `resample_Tsky` when given callable input (i.e. a spline). To be honest, I'm not sure why the test was passing previously...