### PR TITLE
Update for BeamList class compatibility

### DIFF
--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -22,7 +22,7 @@ import time
 
 import numpy as np
 from cached_property import cached_property
-from pyuvdata import UVData
+from pyuvdata import UVData, utils
 from astropy import constants as const
 from collections import OrderedDict
 
@@ -269,7 +269,7 @@ class Simulator(object):
             self.data.set_drift()
 
         # add redundant bl groups to UVData object's extra keywords
-        #self.data.extra_keywords['reds'] = self.data.get_baseline_redundancies()[0]
+        #self.data.extra_keywords['reds'] = self.data.get_redundancies()[0]
 
         # Check if the created/read data is compatible with the assumptions of
         # this class.
@@ -340,7 +340,7 @@ class Simulator(object):
         self.data.data_array[blt_ind, 0, :, pol_ind] += vis
 
     def _get_reds(self):
-        return self.data.get_baseline_redundancies()[0]
+        return self.data.get_redundancies()[0]
 
     def _generate_seeds(self, model):
         if 'seeds' not in self.data.extra_keywords.keys():

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -189,7 +189,7 @@ def test_consistent_across_reds():
     sim.add_foregrounds('diffuse_foreground', Tsky_mdl=HERA_Tsky_mdl['xx'],
             seed_redundantly=True)
     sim.add_eor('noiselike_eor', seed_redundantly=True)
-    reds = sim.data.get_baseline_redundancies()[0][1] # choose non-autos
+    reds = sim.data.get_redundancies()[0][1] # choose non-autos
     key1 = sim.data.baseline_to_antnums(reds[0]) + ('xx',)
     key2 = sim.data.baseline_to_antnums(reds[1]) + ('xx',)
     assert np.all(np.isclose(sim.data.get_data(key1),sim.data.get_data(key2)))

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -10,7 +10,6 @@ from pyuvsim.simsetup import (
     initialize_uvdata_from_params,
     initialize_catalog_from_params,
     uvdata_to_telescope_config,
-    beam_string_to_object,
     _complete_uvdata
 )
 from os import path
@@ -113,7 +112,7 @@ class VisibilitySimulator(object):
             for name, id in self.beam_ids.items():
                 tmp_ids[nms.index(name)] = id
             self.beam_ids = tmp_ids
-            self.beams = [beam_string_to_object(bm) for bm in self.beams]
+            self.beams.set_obj_mode()
             _complete_uvdata(self.uvdata, inplace=True)
         else:
             if uvdata is None:


### PR DESCRIPTION
Fixes a bug caused by recent pyuvsim changes. The `beam_string_to_object` function is deprecated, and beam lists are returned from `initialize_uvdata_from_params` as  `pyuvsim.telescope.BeamList` objects.