### PR TITLE
Added GPU acceleration to vis_cpu

### DIFF
--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -177,20 +177,20 @@ def test_shapes(uvdata, simulator):
 
 
 @pytest.mark.parametrize(
-    "dtype, cdtype",
-    [(np.float32, np.complex64),
-     (np.float32, np.complex128),
-     (np.float64, np.complex128),
-     ]
+    "precision, cdtype",
+    [
+        (1, np.complex64),
+        (2, np.complex128)
+    ]
 )
-def test_dtypes(uvdata, dtype, cdtype):
+def test_dtypes(uvdata, precision, cdtype):
     I_sky = create_uniform_sky()
 
     sim = VisCPU(
         uvdata=uvdata,
         sky_freqs=np.unique(uvdata.freq_array),
         sky_intensity=I_sky,
-        real_dtype=dtype, complex_dtype=cdtype)
+        precision=precision)
 
     v = sim.simulate()
     assert v.dtype == cdtype

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -14,6 +14,20 @@ from hera_sim.visibilities import VisCPU, HealVis
 
 SIMULATORS = (HealVis, VisCPU)
 
+try:
+    import hera_gpu
+
+    class VisGPU(VisCPU):
+        """Simple mock class to make testing VisCPU with use_gpu=True easier"""
+        def __init__(self, *args, **kwargs):
+            self.__init__(*args, use_gpu=True, **kwargs)
+
+    SIMULATORS = SIMULATORS + (VisGPU, )
+except ImportError:
+    pass
+
+
+
 np.random.seed(0)
 NTIMES = 10
 BM_PIX = 31

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -100,7 +100,9 @@ class VisibilitySimulator(object):
                     # If it's not there, it will raise a KeyError.
                     catalog = initialize_catalog_from_params(obsparams)[0]
                     point_source_pos = np.array([catalog['ra_j2000'], catalog['dec_j2000']]).T * np.pi/180.
-                    point_source_flux = np.atleast_2d(catalog['flux_density_I'])
+
+                    # This gets the 'I' component of the flux density
+                    point_source_flux = np.atleast_2d(catalog['flux_density'][:, 0])
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -46,8 +46,10 @@ class VisCPU(VisibilitySimulator):
             try:
                 from hera_gpu.vis import vis_gpu
                 self._vis_cpu = vis_gpu
-            except(ImportError):
-                raise ImportError('GPU acceleration requires hera_gpu (https://github.com/HERA-Team/hera_gpu).')
+            except ImportError:
+                raise ImportError(
+                    'GPU acceleration requires hera_gpu (`pip install hera_sim[gpu]`).'
+                )
         else:
             self._vis_cpu = vis_cpu
         self.bm_pix = bm_pix

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -43,8 +43,11 @@ class VisCPU(VisibilitySimulator):
             self._complex_dtype = np.complex128
 
         if use_gpu:
-            from hera_gpu.vis import vis_gpu
-            self._vis_cpu = vis_gpu
+            try:
+                from hera_gpu.vis import vis_gpu
+                self._vis_cpu = vis_gpu
+            except(ImportError):
+                raise ImportError('GPU acceleration requires hera_gpu (https://github.com/HERA-Team/hera_gpu).')
         else:
             self._vis_cpu = vis_cpu
         self.bm_pix = bm_pix

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -18,8 +18,7 @@ class VisCPU(VisibilitySimulator):
     replaced by vis_gpu. It extends :class:`VisibilitySimulator`.
     """
 
-    def __init__(self, bm_pix=100, real_dtype=np.float32,
-                 complex_dtype=np.complex64, **kwargs):
+    def __init__(self, bm_pix=100, precision=1, use_gpu=False, **kwargs):
         """
         Parameters
         ----------
@@ -34,8 +33,20 @@ class VisCPU(VisibilitySimulator):
             Arguments of :class:`VisibilitySimulator`.
         """
 
-        self._real_dtype = real_dtype
-        self._complex_dtype = complex_dtype
+        assert precision in (1,2)
+        self._precision = precision
+        if precision == 1:
+            self._real_dtype = np.float32
+            self._complex_dtype = np.complex64
+        else:
+            self._real_dtype = np.float64
+            self._complex_dtype = np.complex128
+
+        if use_gpu:
+            from hera_gpu.vis import vis_gpu
+            self._vis_cpu = vis_gpu
+        else:
+            self._vis_cpu = vis_cpu
         self.bm_pix = bm_pix
 
         super(VisCPU, self).__init__(**kwargs)
@@ -165,15 +176,14 @@ class VisCPU(VisibilitySimulator):
                                 dtype=self._complex_dtype)
 
         for i, freq in enumerate(self.freqs):
-            vis = vis_cpu(
+            vis = self._vis_cpu(
                 antpos=self.antpos,
                 freq=freq,
                 eq2tops=eq2tops,
                 crd_eq=crd_eq,
                 I_sky=I[i],
                 bm_cube=beam_lm[:, i],
-                real_dtype=self._real_dtype,
-                complex_dtype=self._complex_dtype,
+                precision=self._precision
             )
 
             indices = np.triu_indices(vis.shape[1])
@@ -232,7 +242,7 @@ class VisCPU(VisibilitySimulator):
 
 
 def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube,
-            real_dtype=np.float32, complex_dtype=np.complex64):
+            precision=1):
     """
     Calculate visibility from an input intensity map and beam model.
 
@@ -268,6 +278,13 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube,
         Visibilities. Shape=(NTIMES, NANTS, NANTS).
     """
 
+    assert precision in (1,2)
+    if precision == 1:
+        real_dtype=np.float32
+        complex_dtype=np.complex64
+    else:
+        real_dtype=np.float64
+        complex_dtype=np.complex128
     nant, ncrd = antpos.shape
     assert ncrd == 3, "antpos must have shape (NANTS, 3)."
     ntimes, ncrd1, ncrd2 = eq2tops.shape

--- a/setup.py
+++ b/setup.py
@@ -60,9 +60,10 @@ setup_args = {
         'astropy-healpix', # pyuvsim depenency not automatically installed,
         "future"
     ],
-    "extras_require" : {
-        "bda" : "bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging"
-        },
+    "extras_require": {
+        "bda": ["bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging"],
+        'gpu': ['hera_gpu @ git+git://github.com/hera-team/hera_gpu'],
+    },
     "version": version.version,
     "package_data": {"hera_sim": data_files},
     "zip_safe": False,


### PR DESCRIPTION
This pull request is pending the merge of vis_gpu support into hera_gpu master. It slightly modifies the vis_cpu function to match the new treatment of data types in vis_gpu, then adds a 'use_gpu" flag to visCPU to enable GPU acceleration.

Results are impressive, as tested on my Thinkpad P1 gen2 laptop with NVIDIA Quadro T2000.

In visibility_simulator.ipynb, jumping to the HERA simulation section and setting nbase = 9 (for a healpix nside of 512 for a 37-element array), healvis estimates:
Finished: 1, Elapsed 5.61min, Remain 4.398hour, MaxRSS 1.258044GB

by setting use_gpu=True in VisCPU for the same simulation, it *completes* in 28 seconds.

All other aspects of VisCPU(..., use_gpu=True) behave identically in the notebook.

Fixes #92.