### PR TITLE
changed recarray column name

### DIFF
--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -102,7 +102,7 @@ class VisibilitySimulator(object):
                     point_source_pos = np.array([catalog['ra_j2000'], catalog['dec_j2000']]).T * np.pi/180.
 
                     # This gets the 'I' component of the flux density
-                    point_source_flux = np.atleast_2d(catalog['flux_density'][:, 0])
+                    point_source_flux = np.atleast_2d(catalog['I'][:])
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).


### PR DESCRIPTION
A somewhat recent change to pyradiosky broke this call -- when a SkyModel is converted to a recarray, the flux data was being kept in a single column called `flux_density`. That has been changed -- separate columns for Stokes I, Q, U, and V are now included (with names simply `I`, `Q`, `U`, `V`).

We will be deprecating the recarray feature in the future, but for now this should fix test_vis.py.