### PR TITLE
Fix setup script (there was a missing comma).

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -54,7 +54,7 @@ setup_args = {
         'scipy',
         'cached_property',
         'pyuvsim>=1.1.2',
-        'pyradiosky @ git+git://github.com/radioastronomysoftwaregroup/pyradiosky'
+        'pyradiosky @ git+git://github.com/radioastronomysoftwaregroup/pyradiosky',
         'pyuvdata',
         'aipy>=3.0',
         'click',


### PR DESCRIPTION
After the recent change, there was a missing comma between the `pyradiosky` install and the `pyuvdata` install in the setup script; this was causing anything that installed `hera_sim` to break.