### PR TITLE
Fix healpix catalog unit conversion

### DIFF
--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -102,8 +102,13 @@ class VisibilitySimulator(object):
                     catalog.at_frequencies(np.unique(self.uvdata.freq_array) * units.Hz)
                     point_source_pos = np.array([catalog.ra.rad, catalog.dec.rad]).T
 
-                    # This gets the 'I' component of the flux density
-                    point_source_flux = np.atleast_2d(catalog.stokes[0].to('Jy').value).T
+                    try:
+                        # This gets the 'I' component of the flux density
+                        point_source_flux = np.atleast_2d(catalog.stokes[0].to('Jy').value).T
+                    except UnitConversionError:
+                        # If the catalog is healpix, converting Stokes 'I' to 'Jy' will give
+                        # `UnitConversionError`. Then, we get the 'I' component as sky intensity.
+                        sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value).T
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -16,6 +16,7 @@ from os import path
 from abc import ABCMeta, abstractmethod
 from astropy import units
 
+
 class VisibilitySimulator(object):
     __metaclass__ = ABCMeta
     """
@@ -92,6 +93,12 @@ class VisibilitySimulator(object):
             (self.uvdata,
              self.beams,
              self.beam_ids) = initialize_uvdata_from_params(obsparams)
+
+            if not (sky_intensity is None and point_source_pos is None and
+                    point_source_flux is None):
+                raise ValueError("If obsparams is given, sky_intensity, "
+                                 "point_source_pos, and point_source_flux "
+                                 "must be None.")
 
             if point_source_pos is None:
                 try:

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -102,16 +102,13 @@ class VisibilitySimulator(object):
                     catalog.at_frequencies(np.unique(self.uvdata.freq_array) * units.Hz)
 
                     try:
-                        point_source_pos = np.array([catalog.ra.rad, catalog.dec.rad]).T
                         # This gets the 'I' component of the flux density
                         point_source_flux = np.atleast_2d(catalog.stokes[0].to('Jy').value).T
+                        point_source_pos = np.array([catalog.ra.rad, catalog.dec.rad]).T
                     except units.UnitConversionError:
                         # If the catalog is healpix, converting Stokes 'I' to 'Jy' will give
                         # `UnitConversionError`. Then, we get the 'I' component as sky intensity.
                         sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value).T
-                        # Make sure `point_source_pos` is set bacck to `None`
-                        # since there is no point source component in this case.
-                        point_source_pos = None
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -108,7 +108,7 @@ class VisibilitySimulator(object):
                     except units.UnitConversionError:
                         # If the catalog is healpix, converting Stokes 'I' to 'Jy' will give
                         # `UnitConversionError`. Then, we get the 'I' component as sky intensity.
-                        sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value).T
+                        sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value)
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -105,7 +105,7 @@ class VisibilitySimulator(object):
                     try:
                         # This gets the 'I' component of the flux density
                         point_source_flux = np.atleast_2d(catalog.stokes[0].to('Jy').value).T
-                    except UnitConversionError:
+                    except units.UnitConversionError:
                         # If the catalog is healpix, converting Stokes 'I' to 'Jy' will give
                         # `UnitConversionError`. Then, we get the 'I' component as sky intensity.
                         sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value).T

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -100,9 +100,9 @@ class VisibilitySimulator(object):
                     # If it's not there, it will raise a KeyError.
                     catalog = initialize_catalog_from_params(obsparams, return_recarray=False)[0]
                     catalog.at_frequencies(np.unique(self.uvdata.freq_array) * units.Hz)
-                    point_source_pos = np.array([catalog.ra.rad, catalog.dec.rad]).T
 
                     try:
+                        point_source_pos = np.array([catalog.ra.rad, catalog.dec.rad]).T
                         # This gets the 'I' component of the flux density
                         point_source_flux = np.atleast_2d(catalog.stokes[0].to('Jy').value).T
                     except units.UnitConversionError:

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -109,6 +109,9 @@ class VisibilitySimulator(object):
                         # If the catalog is healpix, converting Stokes 'I' to 'Jy' will give
                         # `UnitConversionError`. Then, we get the 'I' component as sky intensity.
                         sky_intensity = np.atleast_2d(catalog.stokes[0].to('K').value).T
+                        # Make sure `point_source_pos` is set bacck to `None`
+                        # since there is no point source component in this case.
+                        point_source_pos = None
                 except KeyError:
                     # If 'catalog' was not defined in obsparams, that's fine. We assume
                     # the user has passed some sky model directly (we'll catch it later).


### PR DESCRIPTION
This PR fixes `VisibilitySimulator` to allow reading in a `HEALPix` catalog with the `obsparams` input parameter. 

Assignments of `point_source_pos`, `point_source_flux`, and `sky_intensity` were moved inside a `try-except` block. `astropy.units.UnitConversionError` exception is being used to detect if the catalog is sources or sky intensity in `HEALPix`.

The `HEALPix` catalog already has frequency as the second dimension, so there is no need to transpose.