### PR TITLE
Polarization capabilities for vis_cpu

### DIFF
--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -145,8 +145,8 @@ class PolyBeam(AnalyticBeam):
         if self.polarized:
             interp_data[:,:,:,:] = modulate_with_dipole(az_array, beam_values)
         else:
-            interp_data[1, 0, 0, :, :] = beam_values # (phi, n)
-            interp_data[0, 0, 1, :, :] = beam_values # (theta, e)
+            interp_data[1, 0, 0, :, :] = beam_values # (theta, n)
+            interp_data[0, 0, 1, :, :] = beam_values # (phi, e)
         interp_basis_vector = None
     
         if self.beam_type == 'power':

--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -21,7 +21,7 @@ def modulate_with_dipole(az, beam_vals):
         Array of azimuth values, in radians.
         
     beam_vals : array_like, complex
-        Array of beam values, with same shape as `az`. This will normally be 
+        Array of beam values, with shape (Nfreq, Naz). This will normally be 
         the square-root of a power beam.
     
     Returns
@@ -31,10 +31,13 @@ def modulate_with_dipole(az, beam_vals):
         where 2 = (theta, phi) directions, and N_feed = 2 is the number of 
         linearly-polarised feeds, assumed to be the 'n' and 'e' directions.
     """
+    # dipole_mod: (Naxes, Npol, Naz)
+    # beam_vals: (Nfreq, Naz)
     dipole_mod = (1. - 1.j) * np.array([[-np.sin(az), np.cos(az)], 
                                         [ np.cos(az), np.sin(az)]])
-    pol_beam = dipole_mod[:,np.newaxis,:,:] \
-             * beam_vals[np.newaxis,np.newaxis,np.newaxis,:]
+    pol_beam = dipole_mod[:,np.newaxis,:,np.newaxis,:] \
+             * beam_vals[np.newaxis,np.newaxis,np.newaxis,:,:]
+
     return pol_beam
 
 
@@ -42,7 +45,7 @@ def modulate_with_dipole(az, beam_vals):
 class PolyBeam(AnalyticBeam):
     
     def __init__(self, beam_coeffs=[], spectral_index=0.0, ref_freq=1e8, 
-                 polarized=True, **kwargs):
+                 polarized=False, **kwargs):
         """
         Analytic, azimuthally-symmetric beam model based on Chebyshev 
         polynomials.
@@ -68,7 +71,7 @@ class PolyBeam(AnalyticBeam):
             modulation factor to emulate a polarized beam response. If False, 
             the axisymmetric representation will be put in the (phi, n) 
             and (theta, e) elements of the Jones matrix returned by the 
-            `interp()` method. Default: True.
+            `interp()` method. Default: False.
         """
         self.ref_freq = ref_freq
         self.spectral_index = spectral_index

--- a/hera_sim/tests/test_polybeam.py
+++ b/hera_sim/tests/test_polybeam.py
@@ -170,9 +170,5 @@ class TestPerturbedPolyBeam:
         # Check that ee + nn == unpol, since V_pI = 0.5 * (V_nn + V_ee)
         unpol = 0.5 * (calc_result_ee + calc_result_nn)
         np.testing.assert_almost_equal(unpol, calc_result_unpol, decimal=7)
-        
-        # Check that attempting to use GPU with Polybeam raises an error.
-        with pytest.raises(NotImplementedError):
-            run_sim(r, use_pixel_beams=True, use_gpu=False, use_pol=True) 
 
 

--- a/hera_sim/tests/test_polybeam.py
+++ b/hera_sim/tests/test_polybeam.py
@@ -157,25 +157,20 @@ class TestPerturbedPolyBeam:
     
     def test_perturbed_polybeam_polarized(self):
         
-        # Rotate the beam from 0 to 180 degrees, and check that autocorrelation
-        # of antenna 0 has approximately the same value when pixel beams are
-        # used, and when pixel beams not used (direct beam calculation).
-        rotations = np.zeros(180+1)
-        calc_results_ee = np.zeros(180+1)
-        calc_results_nn = np.zeros(180+1)
-        calc_results_en = np.zeros(180+1)
-        calc_results_ne = np.zeros(180+1)
-        for r in range(0, 180+1):
-            calc_result_ee = run_sim(r, use_pixel_beams=False, use_pol=True, pol='ee')
-            calc_result_nn = run_sim(r, use_pixel_beams=False, use_pol=True, pol='nn') 
-            calc_result_en = run_sim(r, use_pixel_beams=False, use_pol=True, pol='en') 
-            calc_result_ne = run_sim(r, use_pixel_beams=False, use_pol=True, pol='ne') 
-            rotations[r] = r
-            calc_results_ee[r] = calc_result_ee
-            calc_results_nn[r] = calc_result_nn
-            calc_results_en[r] = calc_result_en
-            calc_results_ne[r] = calc_result_ne
-
+        # Calculate all polarizations for a beam rotated by 12 degrees
+        r = 12. # degrees
+        calc_result_ee = run_sim(r, use_pixel_beams=False, use_pol=True, pol='ee')
+        calc_result_nn = run_sim(r, use_pixel_beams=False, use_pol=True, pol='nn') 
+        calc_result_en = run_sim(r, use_pixel_beams=False, use_pol=True, pol='en') 
+        calc_result_ne = run_sim(r, use_pixel_beams=False, use_pol=True, pol='ne') 
+        
+        # Calculate with unrotated, unpolarized beam
+        calc_result_unpol = run_sim(r, use_pixel_beams=False, use_pol=False, pol='ee')
+        
+        # Check that ee + nn == unpol, since V_pI = 0.5 * (V_nn + V_ee)
+        unpol = 0.5 * (calc_result_ee + calc_result_nn)
+        np.testing.assert_almost_equal(unpol, calc_result_unpol, decimal=7)
+        
         # Check that attempting to use GPU with Polybeam raises an error.
         with pytest.raises(NotImplementedError):
             run_sim(r, use_pixel_beams=True, use_gpu=False, use_pol=True) 

--- a/hera_sim/visibilities/conversions.py
+++ b/hera_sim/visibilities/conversions.py
@@ -54,8 +54,8 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
     
     # Peak normalization and reshape output
     if polarized:
-        Naxes = efield_beam.shape[0] # polarization vector axes
-        Nfeeds = efield_beam.shape[1] # polarized feeds
+        Naxes = bm.shape[0] # polarization vector axes
+        Nfeeds = bm.shape[1] # polarized feeds
         
         # Separately normalize each polarization channel
         for i in range(Naxes):

--- a/hera_sim/visibilities/conversions.py
+++ b/hera_sim/visibilities/conversions.py
@@ -5,7 +5,7 @@ import healpy
 import numpy as np
 
 
-def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, **kwargs):
+def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, polarized=False, **kwargs):
     """
     Convert a UVbeam to a uniform (l,m) grid
 
@@ -13,41 +13,62 @@ def uvbeam_to_lm(uvbeam, freqs, n_pix_lm=63, **kwargs):
     ----------
     uvbeam : UVBeam object
         Beam to convert to an (l, m) grid.
+    
     freqs : array_like
         Frequencies to interpolate to in [Hz]. Shape=(NFREQS,).
+    
     n_npix_lm : int, optional
         Number of pixels for each side of the beam grid. Default is 63.
-
+    
+    polarized : bool, optional
+        Whether to return full polarized beam information or not. 
+        Default: False.
+    
     Returns
     -------
     ndarray
-        The beam map cube. Shape=(NFREQS, BEAM_PIX, BEAM_PIX).
+        The beam map cube. Shape: (NFREQS, BEAM_PIX, BEAM_PIX) if 
+        `polarized=False` or (NAXES, NFEEDS, NFREQS, BEAM_PIX, BEAM_PIX) if 
+        `polarized=True`.
     """
-
+    # Define angle cosines
     L = np.linspace(-1, 1, n_pix_lm, dtype=np.float32)
     L, m = np.meshgrid(L, L)
     L = L.flatten()
     m = m.flatten()
-
-    lsqr = L ** 2 + m ** 2
-    n = np.where(lsqr < 1, np.sqrt(1 - lsqr), 0)
-
+    
+    # Apply horizon cut
+    lsqr = L**2. + m**2.
+    n = np.where(lsqr < 1., np.sqrt(1. - lsqr), 0.)
+    
+    # Calculate azimuth and zenith angle
     az = -np.arctan2(m, L)
-    za = np.pi/2 - np.arcsin(n)
-
+    za = np.pi/2. - np.arcsin(n)
+    
+    # Interpolate beam onto cube
     efield_beam = uvbeam.interp(az, za, freqs, **kwargs)[0]
-    efieldXX = efield_beam[0, 0, 1]
-
-    # Get the relevant indices of res
-    bm = np.zeros((len(freqs), len(L)))
-
-    bm = efieldXX
-
-    if np.max(bm) > 0:
-        bm /= np.max(bm)
-
-    return bm.reshape((len(freqs), n_pix_lm, n_pix_lm))
-
+    if polarized:
+        bm = efield_beam[:,0,:,:,:] # spw=0 
+    else:
+        bm = efield_beam[0,0,1,:,:] # (phi, e) == 'xx' component
+    
+    # Peak normalization and reshape output
+    if polarized:
+        Naxes = efield_beam.shape[0] # polarization vector axes
+        Nfeeds = efield_beam.shape[1] # polarized feeds
+        
+        # Separately normalize each polarization channel
+        for i in range(Naxes):
+            for j in range(Nfeeds):
+                if np.max(bm[i,j]) > 0.:
+                    bm /= np.max(bm[i,j])
+        return bm.reshape((Naxes, Nfeeds, len(freqs), n_pix_lm, n_pix_lm))
+    else:
+        # Normalize single polarization channel
+        if np.max(bm) > 0.:
+            bm /= np.max(bm)
+        return bm.reshape((len(freqs), n_pix_lm, n_pix_lm))
+    
 
 def eq2top_m(ha, dec):
     """

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -572,7 +572,7 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
                                         A_s[:,:,i:i+1].conj() \
                                         * v[np.newaxis,np.newaxis,i:i+1].conj(), 
                                         A_s[:,:,i:] \
-                                        * v[np.newaxis,np.newaxis,i:]
+                                        * v[np.newaxis,np.newaxis,i:],
                                         optimize=True )
     
     # Return visibilities with or without multiple polarization channels

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -485,6 +485,12 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
         real_dtype=np.float64
         complex_dtype=np.complex128
     
+    # Specify number of polarizations (axes/feeds)
+    if polarized:
+        nax = nfeed = 2
+    else:
+        nax = nfeed = 1
+    
     if bm_cube is None and beam_list is None:
         raise RuntimeError("One of bm_cube/beam_list must be specified")
     if bm_cube is not None and beam_list is not None:
@@ -501,11 +507,8 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
     
     if beam_list is None:
         bm_pix = bm_cube.shape[-1]
-        assert bm_cube.shape == (
-            nant,
-            bm_pix,
-            bm_pix,
-        ), "bm_cube must have shape (NANTS, BM_PIX, BM_PIX)."
+        assert bm_cube.shape == (nax, nfeed, nant, bm_pix, bm_pix), \
+            "bm_cube must have shape (NAXES, NFEEDS, NANTS, BM_PIX, BM_PIX)."
     else:
         assert len(beam_list) == nant, "beam_list must have length nant"
 
@@ -515,12 +518,6 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
     antpos = antpos.astype(real_dtype)
 
     ang_freq = 2 * np.pi * freq
-    
-    # Specify number of polarizations (axes/feeds)
-    if polarized:
-        nax = nfeed = 2
-    else:
-        nax = nfeed = 1
     
     # Empty arrays: beam pattern, visibilities, delays, complex voltages.
     A_s = np.empty((nax, nfeed, nant, npix), dtype=real_dtype)
@@ -563,7 +560,7 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
                 # Extract requested polarizations
                 for p1 in range(nax):
                     for p2 in range(nfeed):
-                        A_s[p1,p2,i] = splines[p1,p2,i](ty, tx, grid=False)
+                        A_s[p1,p2,i] = splines[p1][p2][i](ty, tx, grid=False)
         else:
             # Primary beam pattern using direct interpolation of UVBeam object
             az, za = conversions.lm_to_az_za(tx, ty)       

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -283,6 +283,7 @@ class VisCPU(VisibilitySimulator):
             # Get x_orientation
             x_orient = self.uvdata.x_orientation
             if x_orient is None:
+                self.uvdata.x_orientation = 'e' # set in UVData object
                 x_orient = 'e' # default to east
             
             # Get polarization strings in terms of n/e feeds
@@ -545,9 +546,9 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
             for i in range(nant):
                 interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
                 if not polarized:
-                    A_s[:,:,i] = interp_beam[0,0,1] # (phi, e) component
+                    A_s[:,:,i] = interp_beam[0,0,1,:,:] # (phi, e) component
                 else:
-                    A_s[:,:,i] = interp_beam[:,0,:]
+                    A_s[:,:,i] = interp_beam[:,0,:,0,:] # spw=0 and freq=0 
         
         # Horizon cut
         A_s = np.where(tz > 0, A_s, 0)

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -342,9 +342,9 @@ class VisCPU(VisibilitySimulator):
                     visfull[:,0,i,p] = vis_upper_tri.flatten()
                     # Shape: (Nblts, Nspws, Nfreqs, Npols)
             else:
-                # Only one polarization
+                # Only one polarization (vis is returned without first 2 dims)
                 indices = np.triu_indices(vis.shape[1])
-                vis_upper_tri = vis[p1,p2, :, indices[0], indices[1]]
+                vis_upper_tri = vis[:, indices[0], indices[1]]
                 visfull[:,0,i,0] = vis_upper_tri.flatten()
         
         # Reduce visfull array if in MPI mode
@@ -456,7 +456,7 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
         ee visibilities.
         
         If False, a single Jones matrix element will be used, corresponding to 
-        the (theta, n) element, i.e. the [1,0,0] component of the beam returned 
+        the (phi, e) element, i.e. the [0,0,1] component of the beam returned 
         by its `interp()` method.
         
         See Eq. 6 of Kohn+ (arXiv:1802.04151) for notation.
@@ -544,8 +544,8 @@ def vis_cpu(antpos, freq, eq2tops, crd_eq, I_sky, bm_cube=None, beam_list=None,
             az, za = conversions.lm_to_az_za(tx, ty)       
             for i in range(nant):
                 interp_beam = beam_list[i].interp(az, za, np.atleast_1d(freq))[0]
-                if pol is None:
-                    A_s[:,:,i] = interp_beam[1,0,0] # (theta, n) component
+                if not polarized:
+                    A_s[:,:,i] = interp_beam[0,0,1] # (phi, e) component
                 else:
                     A_s[:,:,i] = interp_beam[:,0,:]
         


### PR DESCRIPTION
Adds experimental polarisation handling into `vis_cpu`. This supports polarised beams in the direct interpolation and pixel beam modes in `vis_cpu`, but not (yet) for `vis_gpu`. Only feed polarizations are used, i.e. `n` and `e` feeds; the user has to construct pseudo-Stokes visibilities manually. A pure Stokes I sky model is currently assumed.

This PR also adds a simple dipole-modulation polarisation model for `PolyBeam` that is inherited by `PerturbedPolyBeam`.