### PR TITLE
maint: fix version number printing by setuptools_scm

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,7 @@
 requires = ["setuptools>=42", "wheel", "numpy", "setuptools_scm[toml]>=3.4"]
 build-backend = "setuptools.build_meta"
 
-[setuptools_scm]
+[tool.setuptools_scm]
 
 [tool.black]
 line-length = 88


### PR DESCRIPTION
This fixes the version printed when using `python setup.py --version`. We should make a tag on master when this is merged called `v1.0.0`.