### PR TITLE
ci: add deprecation package to ci/tests.yml

### DIFF
--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -26,6 +26,7 @@ dependencies:
     - cached-property
     - pyuvsim[sim]>=1.2,<1.4
     - vis_cpu>=0.2.2
+    - deprecation
     - git+https://github.com/RadioAstronomySoftwareGroup/pyradiosky.git
     - git+https://github.com/HERA-Team/uvtools.git
     - git+https://github.com/rasg-affiliates/healvis


### PR DESCRIPTION
While `deprecation` is being installed in tests because we're installing the package with its deps via pip, it isn't in the `ci/tests.yml` environment. This PR adds it so that pyuvsim can install it more easily.