### PR TITLE
doc: raise warning on using vispu because of baseline conjugation

### DIFF
--- a/hera_sim/tests/test_compare_pyuvsim.py
+++ b/hera_sim/tests/test_compare_pyuvsim.py
@@ -117,6 +117,9 @@ def test_compare_viscpu_with_pyuvsim(nsource, beam_type):
     if "polarized" in beam_type.lower():
         polarized = True
 
+    if not polarized:
+        pytest.skip("This function is broken when polarized=False until hera_sim v2")
+
     # Random antenna locations
     x = np.random.random(nants) * 400.0  # Up to 400 metres
     y = np.random.random(nants) * 400.0

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -64,7 +64,10 @@ class VisCPU(VisibilitySimulator):
 
         warnings.warn(
             "Note that the VisCPU wrapper currently does not properly handle baseline"
-            "conjugation in some cases. This will be remedied in hera_sim v2."
+            "conjugation unless the input uvdata object has ant2<ant1 AND the blt order"
+            "is set to 'time' AND the minor order is set to 'ant2'. Please ensure that "
+            "this is true for your input uvdata object. This will be remedied in "
+            "hera_sim v2."
         )
         assert precision in (1, 2)
         self._precision = precision

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -14,6 +14,8 @@ from astropy.coordinates import EarthLocation
 from vis_cpu import vis_cpu, vis_gpu, HAVE_GPU
 from vis_cpu import conversions as convs
 
+import warnings
+
 
 class VisCPU(VisibilitySimulator):
     """
@@ -60,6 +62,10 @@ class VisCPU(VisibilitySimulator):
         **kwargs
     ):
 
+        warnings.warn(
+            "Note that the VisCPU wrapper currently does not properly handle baseline"
+            "conjugation in some cases. This will be remedied in hera_sim v2."
+        )
         assert precision in (1, 2)
         self._precision = precision
         if precision == 1:


### PR DESCRIPTION
Adds a warning whenever using VisCPU, because it doesn't get baseline conjugation right in all cases. 

Might be better to specify exactly when it gets it wrong, but hopefully just having the warning will be enough until v2 comes.