### PR TITLE
test: don't apply bda in cli test script

### DIFF
--- a/hera_sim/tests/test_simulate_cli.py
+++ b/hera_sim/tests/test_simulate_cli.py
@@ -14,20 +14,6 @@ def config_file(tmp_path_factory):
     cfg_file = tmpdir / "config.yaml"
     cfg_file.write_text(
         f"""
-        bda:
-            max_decorr: 0
-            pre_fs_int_time: !dimensionful
-                value: 0.1
-                units: s
-            corr_fov_angle: !dimensionful
-                value: 20
-                units: deg
-            max_time: !dimensionful
-                value: 16
-                units: s
-            corr_int_time: !dimensionful
-                value: 2
-                units: s
         filing:
             outdir: {str(tmpdir)}
             outfile_name: test.uvh5


### PR DESCRIPTION
The CLI test script currently sets parameters for performing BDA, but it doesn't make sense to apply BDA to the particular set of data being simulated. This PR removes the BDA parameters from the test simulation configuration file.