### PR TITLE
Reflection spectrum

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,18 @@
 Changelog
 =========
 
+v2.2.0 [2022.01.13]
+===================
+
+Added
+-----
+- New ``ReflectionSpectrum`` class to generate multiple reflections over a
+  specified range of delays/amplitudes.
+
+Fixed
+-----
+- Corrected some parameter initializations in ``sigchain`` module.
+
 v2.1.0 [2022.01.12]
 ===================
 

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -136,7 +136,12 @@ class Reflections(Gain):
         self, amp=None, dly=None, phs=None, conj=False, amp_jitter=0, dly_jitter=0
     ):
         super().__init__(
-            amp=amp, dly=dly, phs=phs, conj=conj, amp_jitter=0, dly_jitter=0
+            amp=amp,
+            dly=dly,
+            phs=phs,
+            conj=conj,
+            amp_jitter=amp_jitter,
+            dly_jitter=dly_jitter,
         )
 
     def __call__(self, freqs, ants, **kwargs):
@@ -445,7 +450,12 @@ class CrossCouplingCrosstalk(Crosstalk, Reflections):
         self, amp=None, dly=None, phs=None, conj=False, amp_jitter=0, dly_jitter=0
     ):
         super().__init__(
-            amp=amp, dly=dly, phs=phs, conj=conj, amp_jitter=0, dly_jitter=0
+            amp=amp,
+            dly=dly,
+            phs=phs,
+            conj=conj,
+            amp_jitter=amp_jitter,
+            dly_jitter=dly_jitter,
         )
 
     def __call__(self, freqs, autovis, **kwargs):

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -308,7 +308,7 @@ class Reflections(Gain):
         return amps, dlys, phases
 
 
-class ReflectionSpectrum(Reflections):
+class ReflectionSpectrum(Gain):
     """Generate many reflections between a range of delays.
 
     Amplitudes are distributed on a logarithmic grid, while delays are distributed
@@ -361,7 +361,25 @@ class ReflectionSpectrum(Reflections):
             amp_logbase=amp_logbase,
         )
 
-    def __call__(self, freqs: np.ndarray, ants: Sequence[int], **kwargs):
+    def __call__(
+        self, freqs: np.ndarray, ants: Sequence[int], **kwargs
+    ) -> Dict[int, np.ndarray]:
+        """
+        Generate a series of reflections.
+
+        Parameters
+        ----------
+        freqs
+            Frequencies at which to calculate the reflection coefficients.
+            These should be provided in GHz.
+        ants
+            Antenna numbers for which to generate reflections.
+
+        Returns
+        -------
+        reflection_gains
+            Reflection gains for each antenna.
+        """
         (
             n_copies,
             amp_range,
@@ -376,7 +394,7 @@ class ReflectionSpectrum(Reflections):
         dlys = np.linspace(*dly_range, n_copies)
         phases = np.random.uniform(*phs_range, n_copies)
 
-        reflection_gains = {ant: np.ones_like(freqs)}
+        reflection_gains = {ant: np.ones(freqs.size, dtype=complex) for ant in ants}
         for amp, dly, phs in zip(amps, dlys, phases):
             reflections = Reflections(
                 amp=amp,
@@ -390,7 +408,7 @@ class ReflectionSpectrum(Reflections):
                 reflection_gains[ant] *= reflection
 
         return reflection_gains
-        
+
 
 @component
 class Crosstalk:


### PR DESCRIPTION
Long-overdue PR. This adds a class to handle making a reflection spectrum (typically used to make the "reflection shoulder" seen in H1C data at delays between ~200 and ~1000 ns). Should be ready to merge.