### PR TITLE
fix: don't simulate xtalk for autos

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,12 @@ Changelog
 v2.2.1 [2022.01.14]
 ===================
 
+Added
+-----
+- ``OverAirCrossCoupling`` now has a parameter ``amp_norm``. This lets the user
+  decide at what distance from the receiverator the gain of the emitted signal
+  is equal to the base amplitude.
+
 Fixed
 -----
 - ``OverAirCrossCoupling`` now only simulates the systematic for cross-correlations.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+v2.2.1 [2022.01.14]
+===================
+
+Fixed
+-----
+- ``OverAirCrossCoupling`` now only simulates the systematic for cross-correlations.
+
 v2.2.0 [2022.01.13]
 ===================
 

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -743,7 +743,7 @@ class OverAirCrossCoupling(Crosstalk):
         -------
         xtalk_vis
             Array with the cross-coupling visibility. Has the same shape as the input
-            autocorrelations.
+            autocorrelations. This systematic is not applied to the auto-correlations.
         """
         self._check_kwargs(**kwargs)
         (
@@ -760,6 +760,9 @@ class OverAirCrossCoupling(Crosstalk):
         ) = self._extract_kwarg_values(**kwargs)
 
         ai, aj = antpair
+        if ai == aj:
+            return np.zeros_like(autovis_i)
+
         if emitter_pos is None:
             emitter_pos = np.zeros(3, dtype=float)
         xi = antpos[ai] - np.asarray(emitter_pos)

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -660,6 +660,9 @@ class OverAirCrossCoupling(Crosstalk):
     base_amp
         Base amplitude of reflection coefficient. If `amp_slope` is set to 0, then
         this is the amplitude of all of the reflection coefficients.
+    amp_norm
+        Distance from the receiverator, in meteres, at which the cross-coupling
+        amplitude is equal to ``base_amp``.
     amp_slope
         Power-law index describing how rapidly the reflection coefficient decays
         with distance from the receiverator.
@@ -693,6 +696,7 @@ class OverAirCrossCoupling(Crosstalk):
         emitter_pos: Optional[Union[np.ndarray, Sequence]] = None,
         cable_delays: Optional[Dict[int, float]] = None,
         base_amp: float = 2e-5,
+        amp_norm: float = 100,
         amp_slope: float = -1,
         amp_decay_base: float = 10,
         n_copies: int = 10,
@@ -705,6 +709,7 @@ class OverAirCrossCoupling(Crosstalk):
             emitter_pos=emitter_pos,
             cable_delays=cable_delays or {},
             base_amp=base_amp,
+            amp_norm=amp_norm,
             amp_slope=amp_slope,
             amp_decay_base=amp_decay_base,
             n_copies=n_copies,
@@ -750,6 +755,7 @@ class OverAirCrossCoupling(Crosstalk):
             emitter_pos,
             cable_delay,
             base_amp,
+            amp_norm,
             amp_slope,
             amp_decay_base,
             n_copies,
@@ -765,18 +771,18 @@ class OverAirCrossCoupling(Crosstalk):
 
         if emitter_pos is None:
             emitter_pos = np.zeros(3, dtype=float)
-        xi = antpos[ai] - np.asarray(emitter_pos)
-        xj = antpos[aj] - np.asarray(emitter_pos)
+        xi = np.linalg.norm(antpos[ai] - np.asarray(emitter_pos))
+        xj = np.linalg.norm(antpos[aj] - np.asarray(emitter_pos))
 
         log_scale = np.log(amp_decay_base)
 
         def log(x):
             return np.log(x) / log_scale
 
-        amp_i = base_amp * np.linalg.norm(xi) ** amp_slope
-        amp_j = base_amp * np.linalg.norm(xj) ** amp_slope
-        dly_i = np.linalg.norm(xi) / constants.c.to("m/ns").value
-        dly_j = np.linalg.norm(xj) / constants.c.to("m/ns").value
+        amp_i = base_amp * (xi / amp_norm) ** amp_slope
+        amp_j = base_amp * (xj / amp_norm) ** amp_slope
+        dly_i = xi / constants.c.to("m/ns").value
+        dly_j = xj / constants.c.to("m/ns").value
         dly_ij = cable_delay[ai] + dly_j
         dly_ji = cable_delay[aj] + dly_i
 

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -321,6 +321,12 @@ def test_over_air_cross_coupling(Tsky_mdl, lsts):
         assert np.allclose(ratio, amp, rtol=0.01)
 
 
+def test_over_air_xtalk_skips_autos(fqs, Tsky):
+    gen_xtalk = sigchain.OverAirCrossCoupling()
+    xtalk = gen_xtalk(fqs, (0, 0), range(3), Tsky, Tsky)
+    assert xtalk.shape == Tsky.shape and np.all(xtalk == 0)
+
+
 @pytest.fixture(scope="function")
 def freqs():
     return np.linspace(0.1, 0.2, 1024)


### PR DESCRIPTION
I forgot to make sure that the new cross-coupling model is only applied to cross-correlations. This has been fixed.