### PR TITLE
Fix validation of beam objects.

### DIFF
--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -300,7 +300,7 @@ class TestPerturbedPolyBeam:
 
     @pytest.mark.parametrize("pol", ["ee", "nn", "en", "ne"])
     def test_polarized_validity(self, antennas, sources, pol):
-        beams = self.get_perturbed_beams(12.0)
+        beams = self.get_perturbed_beams(12.0, power_beam=True)
         res = run_sim(
             antennas, sources, beams, use_pixel_beams=True, use_pol=True, pol=pol
         )

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -156,8 +156,8 @@ class VisCPU(VisibilitySimulator):
                 other polarizations afterwards if necessary).
                 """
             )
-        do_pols = self._check_if_polarized(data_model)
-        if do_pols:
+        do_pol = self._check_if_polarized(data_model)
+        if do_pol:
             # If we are simulating polarized visibilities from an unpolarized I sky
             # then the beam must be a power beam that includes the various
             # polarizations present in the data. We would actually need an e-field

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -156,22 +156,23 @@ class VisCPU(VisibilitySimulator):
                 other polarizations afterwards if necessary).
                 """
             )
-
-        # If we are simulating polarized visibilities from an unpolarized I sky
-        # then the beam must be a power beam that includes the various
-        # polarizations present in the data. We would actually need an e-field
-        # beam if we were simulating
-        # a polarized sky so this will need to be changed once we include
-        # polarized sky emission.
-        for polnum in uvdata.polarization_array:
-            if polnum not in uvbeam.polarization_array:
-                raise ValueError(
-                    """
-                    Not all polarizations in uvdata are present in uvbeam.
-                    Make sure you are providing a power beam with all polarizations
-                    in uvdata present!
-                    """
-                )
+        do_pols = self._check_if_polarized(data_model)
+        if do_pols:
+            # If we are simulating polarized visibilities from an unpolarized I sky
+            # then the beam must be a power beam that includes the various
+            # polarizations present in the data. We would actually need an e-field
+            # beam if we were simulating
+            # a polarized sky so this will need to be changed once we include
+            # polarized sky emission.
+            for polnum in uvdata.polarization_array:
+                if polnum not in uvbeam.polarization_array:
+                    raise ValueError(
+                        """
+                        Not all polarizations in uvdata are present in uvbeam.
+                        Make sure you are providing a power beam with all polarizations
+                        in uvdata present!
+                        """
+                    )
 
         if self.use_gpu:
             raise RuntimeError(

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -157,20 +157,20 @@ class VisCPU(VisibilitySimulator):
                 """
             )
 
-
         # If we are simulating polarized visibilities from an unpolarized I sky
-        # then the beam must be a power beam that includes the various polarizations.
-        # present in the data. We would actually need an e-field beam if we were simulating
-        # from a polarized sky so this will need to be changed once we include
+        # then the beam must be a power beam that includes the various
+        # polarizations present in the data. We would actually need an e-field
+        # beam if we were simulating
+        # a polarized sky so this will need to be changed once we include
         # polarized sky emission.
         for polnum in uvdata.polarization_array:
             if polnum not in uvbeam.polarization_array:
                 raise ValueError(
-                """
-                Not all polarizations in uvdata are present in uvbeam.
-                Make sure you are providing a power beam with all polarizations
-                in uvdata present!
-                """
+                    """
+                    Not all polarizations in uvdata are present in uvbeam.
+                    Make sure you are providing a power beam with all polarizations
+                    in uvdata present!
+                    """
                 )
 
         if self.use_gpu:


### PR DESCRIPTION
This PR fixes a validation step for vis_cpu which currently forces the user to input `efield` beams if the `xy` and `yx` pols are to be simulated. However, `vis_cpu` actually operates on power beams and should use the `xy` and `yx` power beams. As things are currently written, if the `xy` and/or `yx` visibility pols are to be simulated then the user is forced to provide an efield beam which will silently and incorrectly apply an efield beam to the sky intensity within `vis_cpu`, producing spurious results. 

I have fixed this by changing the validation step to correctly require that the cross-pol power beams are present instead. This is what should be done for an unpolarized sky. 