### PR TITLE
feat: option to peak-normalize beams in ModelData

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,15 @@
 Changelog
 =========
 
+v2.3.0 [2022.01.19]
+===================
+
+Added
+-----
+- ``normalize_beams`` option in ``ModelData`` class. Setting this parameter to
+  ``True`` enforces peak-normalization on all of the beams used in the simulation.
+  The default behavior is to not peak-normalize the beams.
+
 v2.2.1 [2022.01.14]
 ===================
 


### PR DESCRIPTION
This PR adds a `normalize_beams` option to the `ModelData` initialization routine. If set to `True`, this ensures that all of the beams used are peak-normalized. I'm not sure if this is necessarily exactly how we want to do it in the long-term (since it doesn't put the updated `bandpass_array` anywhere), but it should be a quick patch that adds a bit of extra functionality we discussed in the Validation call.