### PR TITLE
fix: set normalize_beams in ModelData.from_config

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v2.3.1 [2022.01.19]
+===================
+
+Fixed
+-----
+- Using the ``normalize_beams`` option is now possible with the ``from_config``
+  class method.
+
 v2.3.0 [2022.01.19]
 ===================
 

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -166,7 +166,9 @@ class ModelData:
             )
 
     @classmethod
-    def from_config(cls, config_file: str | Path) -> ModelData:
+    def from_config(
+        cls, config_file: str | Path, normalize_beams: bool = False
+    ) -> ModelData:
         """Initialize the :class:`ModelData` from a pyuvsim-compatible config."""
         uvdata, beams, beam_ids = initialize_uvdata_from_params(config_file)
         catalog = initialize_catalog_from_params(config_file, return_recarray=False)[0]
@@ -178,6 +180,7 @@ class ModelData:
             beams=beams,
             beam_ids=beam_ids,
             sky_model=catalog,
+            normalize_beams=normalize_beams,
         )
 
     @cached_property


### PR DESCRIPTION
It's now possible to set the `normalize_beams` parameter using the `ModelData.from_config` class method.