### PR TITLE
fix: only add Trx bias to autocorr noise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,14 @@
 Changelog
 =========
 
+v2.3.2 [2022.02.18]
+===================
+
+Fixed
+-----
+- The ``ThermalNoise`` class ``__call__`` method is now aware of baseline
+  length so that autocorrelations only receive a receiver temperature bias.
+
 v2.3.1 [2022.01.19]
 ===================
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,10 +5,20 @@ Changelog
 v2.3.2 [2022.02.18]
 ===================
 
+Added
+-----
+- ``_extract_kwargs`` attribute added to the ``SimulationComponent`` class. This
+  attribute is used by the ``Simulator`` to determine which optional parameters
+  should actually be extracted from the data.
+- ``antpair`` optional parameter added to the ``ThermalNoise`` class. This is
+  used to determine whether to simulate noise via the radiometer equation (as is
+  appropriate for a cross-correlation) or to just add a bias from the receiver
+  temperature (which is our proxy for what should happen to an auto-correlation).
+
 Fixed
 -----
-- The ``ThermalNoise`` class ``__call__`` method is now aware of baseline
-  length so that autocorrelations only receive a receiver temperature bias.
+- The ``Simulator`` class now correctly uses the auto-correlations to simulate
+  noise for the cross-correlations.
 
 v2.3.1 [2022.01.19]
 ===================

--- a/hera_sim/components.py
+++ b/hera_sim/components.py
@@ -39,6 +39,9 @@ class SimulationComponent(metaclass=ABCMeta):
 
     _alias: Tuple[str] = tuple()
 
+    # Keyword arguments for the Simulator to extract from the data
+    _extract_kwargs = set()
+
     def __init_subclass__(cls, is_abstract: bool = False):
         """Provide some useful augmentations to subclasses.
 

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -211,7 +211,7 @@ def sky_noise_jy(lsts: np.ndarray, freqs: np.ndarray, **kwargs):
     ndarray
         2D array of white noise in LST/freq.
     """
-    return thermal_noise(lsts, freqs, Trx=0, **kwargs)
+    return thermal_noise(lsts, freqs, bl_vec=100, Trx=0, **kwargs)
 
 
 def white_noise(*args, **kwargs):

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -885,7 +885,11 @@ class Simulator:
         has a default value, it will not be in the returned dictionary.
         """
         model_params = self._get_model_parameters(model)
-        model_params = {k: v for k, v in model_params.items() if v is inspect._empty}
+        model_params = {
+            k: v
+            for k, v in model_params.items()
+            if v is inspect._empty or k in model._extract_kwargs
+        }
 
         # Pull the LST and frequency arrays if they are required.
         # TODO: update this to allow more flexibility in which arguments are

--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -152,7 +152,7 @@ def run_sim(
         use_pixel_beams=use_pixel_beams,
         use_gpu=use_gpu,
         mpi_comm=DummyMPIComm() if use_mpi else None,
-        bm_pix=200,
+        bm_pix=201,
         precision=2,
     )
 

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -212,15 +212,16 @@ def test_get_with_one_seed(base_sim, pol, conj):
 # TODO: this will need to be updated when full polarization support is added
 @pytest.mark.parametrize("pol", [None, "xx"])
 @pytest.mark.parametrize("conj", [True, False])
-def test_get_with_initial_seed(base_sim, pol, conj):
+def test_get_with_initial_seed(pol, conj):
     # Simulate an effect where we would actually use this setting.
-    base_sim.add("thermal_noise", seed="initial")
+    sim = create_sim(autos=True)
+    sim.add("thermal_noise", seed="initial")
     ant1, ant2 = (0, 1) if conj else (1, 0)
-    vis = base_sim.get("thermal_noise", key=(ant1, ant2, pol))
+    vis = sim.get("thermal_noise", key=(ant1, ant2, pol))
     if pol:
-        assert np.allclose(base_sim.data.get_data(ant1, ant2, pol), vis)
+        assert np.allclose(sim.data.get_data(ant1, ant2, pol), vis)
     else:
-        assert np.allclose(base_sim.data.get_data(ant1, ant2), vis[..., 0])
+        assert np.allclose(sim.data.get_data(ant1, ant2), vis[..., 0])
 
 
 def test_get_nonexistent_component(ref_sim):

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -74,7 +74,7 @@ class VisCPU(VisibilitySimulator):
 
     def __init__(
         self,
-        bm_pix: int = 100,
+        bm_pix: int = 101,
         use_pixel_beams: bool = True,
         precision: int = 1,
         use_gpu: bool = False,


### PR DESCRIPTION
This PR makes sure that autocorrelations only receive a receiver temperature bias when using the `ThermalNoise` class to simulate noise. This is exactly what we did for H1C IDR2 validation, but I forgot to transfer it over to `hera_sim`.

Edit: Many tests broke as a result of recent changes to `vis_cpu`. I've also fixed those tests in this PR.