### PR TITLE
Fix interp

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+v2.3.3 [2022.02.21]
+===================
+
+Added
+-----
+- ``adjustment.interpolate_to_reference`` now supports interpolating in time when
+  there is a phase wrap in LST.
+
+Changed
+-------
+- Some logical statements in ``adjustment.interpolate_to_reference`` were changed
+  to use binary operators on logical arrays instead of e.g. ``np.logical_or``.
+
 v2.3.2 [2022.02.18]
 ===================
 

--- a/hera_sim/adjustment.py
+++ b/hera_sim/adjustment.py
@@ -521,14 +521,16 @@ def interpolate_to_reference(
 
         if np.any((ref_lsts < target_lsts[0]) | (ref_lsts > target_lsts[-1])):
             warn("Reference LSTs not a subset of target LSTs; clipping.")
-            key = (target_lsts[0] <= ref_lsts) & (ref_lsts <= target_lsts[-1])
-            ref_times = ref_times[key]
-            ref_lsts = ref_lsts[key]
+            is_in_range = (target_lsts[0] <= ref_lsts) & (ref_lsts <= target_lsts[-1])
+            ref_times = ref_times[is_in_range]
+            ref_lsts = ref_lsts[is_in_range]
     if axis in ("freq", "both"):
         if np.any((ref_freqs < target_freqs[0]) | (ref_freqs > target_freqs[-1])):
             warn("Reference frequencies not a subset of target frequencies; clipping.")
-            key = (target_freqs[0] <= ref_freqs) & (ref_freqs <= target_freqs[-1])
-            ref_freqs = ref_freqs[key]
+            is_in_range = (target_freqs[0] <= ref_freqs) & (
+                ref_freqs <= target_freqs[-1]
+            )
+            ref_freqs = ref_freqs[is_in_range]
 
     # Setup data/metadata objects that need to be non-trivially rewritten.
     if axis in ("time", "both"):


### PR DESCRIPTION
This PR adds support for interpolating in time when there is a phase wrap in the LSTs. This works on the assumption that the time array is strictly increasing. It's possible that I may have over-simplified it and there might be poorly-handled edge cases, but I think this update does the right thing.