### PR TITLE
Temporary fix for future array shape

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -2,6 +2,13 @@
 Changelog
 =========
 
+dev-version
+===========
+
+Changed
+-------
+- Temporarily forced all UVData objects in the code to use current array shapes.
+
 v2.3.3 [2022.02.21]
 ===================
 

--- a/hera_sim/io.py
+++ b/hera_sim/io.py
@@ -114,6 +114,10 @@ def empty_uvdata(
     if conjugation is not None:
         uvd.conjugate_bls(convention=conjugation)
 
+    # Temporary fix for future array shape - to be removed after v3.
+    if uvd.future_array_shapes:
+        uvd.use_current_array_shapes()
+
     return uvd
 
 

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -5,6 +5,7 @@ import pytest
 from astropy.units import sday, rad
 from astropy import units
 from pyuvsim.analyticbeam import AnalyticBeam
+from pyuvsim.telescope import BeamConsistencyError
 from vis_cpu import HAVE_GPU
 from hera_sim.defaults import defaults
 from hera_sim import io
@@ -357,6 +358,7 @@ def test_autocorr_flat_beam(uvdata, simulator):
 
     v = sim.uvdata.get_data((0, 0, "xx"))
 
+    print(v)
     # The sky is uniform and integrates to one over the full sky.
     # Thus the stokes-I component of an autocorr will be 0.5 (going to horizon)
     # Since I = XX + YY and X/Y should be equal, the xx part should be 0.25
@@ -619,7 +621,7 @@ def test_beam_type_consistency(uvdata, sky_model):
     beams = [AnalyticBeam("gaussian"), AnalyticBeam("airy")]
     beams[0].efield_to_power()
 
-    with pytest.raises(ValueError):
+    with pytest.raises(BeamConsistencyError):
         ModelData(uvdata=uvdata, sky_model=sky_model, beams=beams)
 
 

--- a/hera_sim/visibilities/pyuvsim_wrapper.py
+++ b/hera_sim/visibilities/pyuvsim_wrapper.py
@@ -52,4 +52,5 @@ class UVSim(VisibilitySimulator):
             catalog=pyuvsim.simsetup.SkyModelData(data_model.sky_model),
             quiet=self.quiet,
         )
+        out_uv.use_current_array_shapes()
         return out_uv.data_array

--- a/hera_sim/visibilities/pyuvsim_wrapper.py
+++ b/hera_sim/visibilities/pyuvsim_wrapper.py
@@ -53,4 +53,5 @@ class UVSim(VisibilitySimulator):
             quiet=self.quiet,
         )
         out_uv.use_current_array_shapes()
+        data_model.uvdata.use_current_array_shapes()
         return out_uv.data_array

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -88,10 +88,16 @@ class ModelData:
 
     def _process_uvdata(self, uvdata: UVData | str | Path):
         if isinstance(uvdata, UVData):
+            # Temporary fix for future array shape - to be removed after v3.
+            if uvdata.future_array_shapes:
+                uvdata.use_current_array_shapes()
             return uvdata
         elif isinstance(uvdata, (str, Path)):
             out = UVData()
             out.read(str(uvdata))
+            # Temporary fix for future array shape - to be removed after v3.
+            if out.future_array_shapes:
+                out.use_current_array_shapes()
             return out
         else:
             raise TypeError(

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -87,23 +87,23 @@ class ModelData:
         self._validate()
 
     def _process_uvdata(self, uvdata: UVData | str | Path):
-        if isinstance(uvdata, UVData):
-            # Temporary fix for future array shape - to be removed after v3.
-            if uvdata.future_array_shapes:
-                uvdata.use_current_array_shapes()
-            return uvdata
-        elif isinstance(uvdata, (str, Path)):
+
+        if isinstance(uvdata, (str, Path)):
             out = UVData()
             out.read(str(uvdata))
-            # Temporary fix for future array shape - to be removed after v3.
-            if out.future_array_shapes:
-                out.use_current_array_shapes()
-            return out
-        else:
+            uvdata = out
+
+        if not isinstance(uvdata, UVData):
             raise TypeError(
                 "uvdata must be a UVData object or path to a compatible file. Got "
                 f"{uvdata}, type {type(uvdata)}"
             )
+
+        # Temporary fix for future array shape - to be removed after v3.
+        if uvdata.future_array_shapes:
+            uvdata.use_current_array_shapes()
+
+        return uvdata
 
     @classmethod
     def _process_beams(cls, beams: BeamListType | None, normalize_beams: bool):


### PR DESCRIPTION
pyuvdata switched to using `future_array_shapes` by default from `pyuvdata>=2.7.0`. Many functionalities of `hera_sim=2.x.x` relies on the `current_array_shapes` (see, e.g., #211). This PR provides a temporary fix to this issue  The full fix is planned for `hera_sim=3.x.x`.