### PR TITLE
fix: inferred integration time in ThermalNoise

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,15 @@ Changelog
 dev-version
 ===========
 
+Added
+-----
+- ``NotImplementedError`` raised when trying to simulate noise using an interpolated
+  sky temperature and phase-wrapped LSTs.
+
+Fixed
+-----
+- Inferred integration time in ``ThermalNoise`` when phase-wrapped LSTs are used.
+
 Changed
 -------
 - Temporarily forced all UVData objects in the code to use current array shapes.

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -96,6 +96,13 @@ class ThermalNoise(Noise):
             A 2D array shaped ``(lsts, freqs)`` with the thermal noise. If the
             provided ``antpair`` is for an autocorrelation, then only a receiver
             temperature bias is returned.
+
+        Raises
+        ------
+        NotImplementedError
+            This method does not yet have support for handling the case when the
+            provided LST array has a phase wrap and a sky temperature interpolation
+            object is intended to be used to simulate the noise.
         """
         # validate the kwargs
         self._check_kwargs(**kwargs)
@@ -115,9 +122,19 @@ class ThermalNoise(Noise):
         if channel_width is None:
             channel_width = np.mean(np.diff(freqs)) * 1e9
 
+        # Check whether there's a phase wrap in the provided LSTs.
+        iswrapped = np.any(lsts < lsts[0])
+        if iswrapped and autovis is None and Tsky_mdl is not None:
+            raise NotImplementedError(
+                "Edge cases with wrapped LSTs and sky temperature interpolation "
+                "objects haven't been worked out yet."
+            )
+
         # get the integration time if not specified
         if integration_time is None:
-            integration_time = np.mean(np.diff(lsts)) / (2 * np.pi)
+            integration_time = np.mean(
+                np.diff(np.where(lsts < lsts[0], lsts + 2*np.pi, lsts))
+            ) / (2 * np.pi)
             integration_time *= u.sday.to("s")
 
         # default to H1C beam if not specified

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -125,7 +125,12 @@ def test_thermal_noise_with_phase_wrap(freqs, omega_p, autovis, expectation):
     Trx = 0
     if autovis is not None:
         autovis = np.ones((wrapped_lsts.size, freqs.size), dtype=complex)
-    noise_sim = noise.ThermalNoise(omega_p=omega_p, Trx=Trx, autovis=autovis)
+    noise_sim = noise.ThermalNoise(
+        Tsky_mdl=noise.HERA_Tsky_mdl["xx"],
+        omega_p=omega_p,
+        Trx=Trx,
+        autovis=autovis,
+    )
     with expectation:
         vis = noise_sim(lsts=wrapped_lsts, freqs=freqs)
         assert np.isclose(np.std(vis), 1 / expected_SNR, rtol=1 / np.sqrt(vis.size))


### PR DESCRIPTION
Without this fix, the inferred integration time for a phase-wrapped LST array is negative for most use cases, which causes the calculated noise to take on nan values. This commit fixes that issue, but it also adds an exception for the case where the LSTs are phase-wrapped and the sky temperature is intended to be calculated from an interpolation object. (This case would have been handled poorly prior to this fix, so this just makes the error more explicit.)