### PR TITLE
Add dummy select() method to PolyBeam classes

### DIFF
--- a/.github/workflows/pre_commit.yaml
+++ b/.github/workflows/pre_commit.yaml
@@ -17,4 +17,4 @@ jobs:
       with:
         path: ~/.cache/pre-commit
         key: pre-commit|${{ env.PY }}|${{ hashFiles('.pre-commit-config.yaml') }}
-    - uses: pre-commit/action@v1.1.0
+    - uses: pre-commit/action@v2.0.3

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,7 +1,7 @@
 exclude: 'config.yaml|config_examples/*.yaml|hera_sim/config/H1C.yaml|hera_sim/config/H2C.yaml|setup.py'
 
 repos:
-- repo: git://github.com/pre-commit/pre-commit-hooks
+- repo: https://github.com/pre-commit/pre-commit-hooks
   rev: v4.1.0
   hooks:
   - id: trailing-whitespace

--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -310,6 +310,9 @@ class PolyBeam(AnalyticBeam):
         # Not required
         pass
 
+    def select(self, **kwargs):
+        pass
+
     def interp(self, az_array, za_array, freq_array, reuse_spline=None):
         """
         Evaluate the primary beam at given az, za locations (in radians).

--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -311,6 +311,7 @@ class PolyBeam(AnalyticBeam):
         pass
 
     def select(self, **kwargs):
+        """Dummy select method."""
         pass
 
     def interp(self, az_array, za_array, freq_array, reuse_spline=None):

--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -290,7 +290,7 @@ class TestPerturbedPolyBeam:
         # Check that PolyBeam classes have a select() method, but that it does nothing
         beams = self.get_perturbed_beams(180.0, power_beam=True)
         for beam in beams:
-            assert beam == beam.select(any_kwarg_should_work=1)
+            beam.select(any_kwarg_should_work=1)
 
     def test_gpu_fails(self, antennas, sources):
         # Check that power beam calculation returns values

--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -286,6 +286,12 @@ class TestPerturbedPolyBeam:
         calc_result = run_sim(antennas, sources, beams, use_pixel_beams=False)
         assert np.all(np.isfinite(calc_result))
 
+    def test_beam_select(self, antennas, sources):
+        # Check that PolyBeam classes have a select() method, but that it does nothing
+        beams = self.get_perturbed_beams(180.0, power_beam=True)
+        for beam in beams:
+            assert beam == beam.select(any_kwarg_should_work=1)
+
     def test_gpu_fails(self, antennas, sources):
         # Check that power beam calculation returns values
         beams = self.get_perturbed_beams(180.0)

--- a/setup.cfg
+++ b/setup.cfg
@@ -52,11 +52,11 @@ exclude =
 
 [options.extras_require]
 bda =
-    bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging
+    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging
 gpu =
-    hera_gpu @ git+git://github.com/hera-team/hera_gpu
+    hera_gpu @ git+https://github.com/hera-team/hera_gpu
 cal =
-    hera_cal @ git+git://github.com/hera-team/hera_cal
+    hera_cal @ git+https://github.com/hera-team/hera_cal
 docs =
     sphinx>=1.8
     nbsphinx
@@ -70,10 +70,10 @@ tests =
     pytest-cov>=2.5.1
     pre-commit
     matplotlib>=3.4.2
-    uvtools @ git+git://github.com/HERA-Team/uvtools.git
-    hera_cal @ git+git://github.com/hera-team/hera_cal
-    healvis @ git+git://github.com/rasg-affiliates/healvis
-    bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging.git
+    uvtools @ git+https://github.com/HERA-Team/uvtools.git
+    hera_cal @ git+https://github.com/hera-team/hera_cal
+    healvis @ git+https://github.com/rasg-affiliates/healvis
+    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging.git
     vis_cpu>=0.4.1<1.0
 dev =
     sphinx>=1.8
@@ -84,14 +84,14 @@ dev =
     pytest>=3.5.1
     pytest-cov>=2.5.1
     pre-commit
-    uvtools @ git+git://github.com/HERA-Team/uvtools.git
-    healvis @ git+git://github.com/rasg-affiliates/healvis
-    hera_cal @ git+git://github.com/hera-team/hera_cal
-    bda @ git+git://github.com/HERA-Team/baseline_dependent_averaging.git
+    uvtools @ git+https://github.com/HERA-Team/uvtools.git
+    healvis @ git+https://github.com/rasg-affiliates/healvis
+    hera_cal @ git+https://github.com/hera-team/hera_cal
+    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging.git
     vis_cpu>=0.4.1<1.0
 vis =
     vis_cpu>=0.4.1<1.0
-    healvis @ git+git://github.com/RASG-Affiliates/healvis
+    healvis @ git+https://github.com/RASG-Affiliates/healvis
     pyradiosky>=0.1.2
 
 [tool:pytest]


### PR DESCRIPTION
Trivial PR to add a dummy `select()` method to the `PolyBeam` class, so it can be used by the new-style hera_sim `VisibilitySimulator` class.

Incidentally, this also fixes an issue with the pre-commit hooks using a now-deprecated GitHub access URL.