### PR TITLE
maint: remove all git repo deps

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,15 +5,20 @@ Changelog
 dev-version
 ===========
 
+v2.3.4 [2022.06.08]
+===================
+
 Added
 -----
 - ``NotImplementedError`` raised when trying to simulate noise using an interpolated
   sky temperature and phase-wrapped LSTs.
+- More comparison tests of pyuvsim wrapper.
 
 Fixed
 -----
 - Inferred integration time in ``ThermalNoise`` when phase-wrapped LSTs are used.
-- Added **kwargs to ``PolyBeam.interp`` method to match UVBeam.
+- Added ``**kwargs`` to ``PolyBeam.interp`` method to match UVBeam.
+- healvis wrapper properly sets cross-pol visibilities to zero.
 
 Changed
 -------

--- a/ci/tests.yaml
+++ b/ci/tests.yaml
@@ -24,11 +24,11 @@ dependencies:
   - git
   - pip:
     - cached-property
-    - pyuvsim[sim]>=1.2,<1.4
+    - pyuvsim[sim]>=1.2
     - vis_cpu>=0.2.2
     - deprecation
     - pyradiosky
-    - git+https://github.com/HERA-Team/uvtools.git
+    - uvtools
     - git+https://github.com/rasg-affiliates/healvis
-    - git+https://github.com/HERA-Team/hera_cal.git
-    - git+https://github.com/HERA-Team/baseline_dependent_averaging.git
+    - hera-calibration
+    - bda

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -56,6 +56,8 @@ extensions = [
 autosectionlabel_prefix_document = True
 autosummary_generate = True
 
+autodoc_mock_imports = ["healvis"]
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ["_templates"]
 

--- a/hera_sim/adjustment.py
+++ b/hera_sim/adjustment.py
@@ -23,7 +23,7 @@ try:
     HERA_CAL = True
 except (ModuleNotFoundError, FileNotFoundError) as err:  # pragma: no cover
     if err is ModuleNotFoundError:
-        missing = "hera_cal"
+        missing = "hera-calibration"
     else:
         missing = "git"
     warn(f"{missing} is not installed. Rephasing tool unavailable.")
@@ -669,7 +669,7 @@ def rephase_to_reference(
     """
     if not HERA_CAL:  # pragma: no cover
         raise NotImplementedError(
-            "You must have ``hera_cal`` installed to use this function."
+            "You must have ``hera-calibration`` installed to use this function."
         )
 
     # Convert target to a HERAData object.

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -11,7 +11,6 @@ from hera_sim.defaults import defaults
 from hera_sim import io
 from hera_sim.visibilities import (
     VisCPU,
-    HealVis,
     VisibilitySimulation,
     ModelData,
     UVSim,
@@ -25,7 +24,14 @@ from astropy import time as apt
 import copy
 from pathlib import Path
 
-SIMULATORS = (HealVis, VisCPU, UVSim)
+SIMULATORS = (VisCPU, UVSim)
+
+try:
+    from hera_sim.visibilities import HealVis
+
+    SIMULATORS = SIMULATORS + (HealVis,)
+except ImportError:
+    pass
 
 if HAVE_GPU:
 
@@ -111,6 +117,7 @@ def sky_modelJD(uvdataJD):
 
 
 def test_healvis_beam(uvdata, sky_model):
+    pytest.importorskip("healvis")
     sim = VisibilitySimulation(
         simulator=HealVis(),
         data_model=ModelData(
@@ -126,6 +133,7 @@ def test_healvis_beam(uvdata, sky_model):
 
 def test_healvis_beam_obsparams(tmpdir):
     # Now try creating with an obsparam file
+    pytest.importorskip("healvis")
     direc = tmpdir.mkdir("test_healvis_beam")
 
     with open(direc.join("catalog.txt"), "w") as fl:
@@ -479,21 +487,23 @@ def align_src_to_healpix(ra, dec, nside=2**4):
     ],
 )
 def test_comparison(uvdata2, sky_model, beam_model):
-    cpu = VisCPU()
-    healvis = HealVis()
+    simulators = [sim() for sim in SIMULATORS]
 
     model_data = ModelData(
         uvdata=uvdata2, sky_model=sky_model(uvdata2), beams=beam_model
     )
 
-    viscpu = VisibilitySimulation(data_model=model_data, simulator=cpu).simulate()
+    vissims = [
+        VisibilitySimulation(
+            data_model=model_data, simulator=sim, n_side=2**4
+        ).simulate()
+        for sim in simulators
+    ]
 
-    healvis = VisibilitySimulation(
-        data_model=model_data, simulator=healvis, n_side=2**4
-    ).simulate()
+    assert all(v.shape == vissims[0].shape for v in vissims)
 
-    assert viscpu.shape == healvis.shape
-    np.testing.assert_allclose(viscpu, healvis, rtol=0.05)
+    for v in vissims:
+        np.testing.assert_allclose(vissims[0], v, rtol=0.05)
 
 
 def test_vis_cpu_pol_gpu(uvdata_linear):
@@ -662,6 +672,7 @@ def test_str_uvdata(uvdata, sky_model, tmp_path):
 
 
 def test_bad_healvis_skymodel(sky_model):
+    pytest.importorskip("healvis")
     hv = HealVis()
     sky_model.stokes *= units.sr  # something stupid
     with pytest.raises(ValueError, match="not compatible with healvis"):
@@ -669,6 +680,7 @@ def test_bad_healvis_skymodel(sky_model):
 
 
 def test_mK_healvis_skymodel(sky_model):
+    pytest.importorskip("healvis")
     hv = HealVis()
     sky_model.stokes = sky_model.stokes.value * units.mK
     sky_model.nside = 2**3

--- a/hera_sim/visibilities/healvis_wrapper.py
+++ b/hera_sim/visibilities/healvis_wrapper.py
@@ -45,6 +45,14 @@ class HealVis(VisibilitySimulator):
         if not HAVE_HEALVIS:
             raise ImportError("to use the healvis wrapper, you must install healvis!")
 
+        warnings.warn(
+            (
+                "The healvis package is deprecated. Please use pyuvsim instead. "
+                "The healvis wrapper will be removed from hera_sim in version 4",
+            ),
+            category=DeprecationWarning,
+        )
+
         self.fov = fov
         self._nprocs = nprocesses
         self._sky_ref_chan = sky_ref_chan

--- a/hera_sim/visibilities/healvis_wrapper.py
+++ b/hera_sim/visibilities/healvis_wrapper.py
@@ -163,9 +163,15 @@ class HealVis(VisibilitySimulator):
 
         # Simulate the visibilities for each polarization.
         for pol in data_model.uvdata.get_pols():
-            visibility, _, baselines = obs.make_visibilities(
-                sky, Nprocs=self._nprocs, beam_pol=pol
-            )  # Shape (Nblts, Nskies, Nfreqs)
+            if pol in ["xx", "yy"]:
+                visibility, _, baselines = obs.make_visibilities(
+                    sky, Nprocs=self._nprocs, beam_pol=pol
+                )  # Shape (Nblts, Nskies, Nfreqs)
+            else:
+                # healvis doesn't support polarization
+                visibility = np.zeros(
+                    (data_model.uvdata.Nblts, 1, data_model.uvdata.Nfreqs)
+                )
 
             # AnalyticBeams do not use polarization at all in healvis, and are
             # equivalent to "pI" polarization. To match our definition of linear pols

--- a/setup.cfg
+++ b/setup.cfg
@@ -54,11 +54,12 @@ exclude =
 
 [options.extras_require]
 bda =
-    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging
+    bda
 gpu =
-    hera_gpu @ git+https://github.com/hera-team/hera_gpu
+    pycuda
+    scikit-cuda
 cal =
-    hera_cal @ git+https://github.com/hera-team/hera_cal
+    hera_cal
 docs =
     sphinx>=1.8
     nbsphinx
@@ -66,8 +67,7 @@ docs =
     sphinx_autorun
     numpydoc>=0.8
     nbsphinx
-    vis_cpu>=0.4.1<1.0
-    healvis @ git+https://github.com/RASG-Affiliates/healvis
+    vis_cpu>=0.4.1
     pyradiosky>=0.1.2
 tests =
     coverage>=4.5.1
@@ -75,11 +75,10 @@ tests =
     pytest-cov>=2.5.1
     pre-commit
     matplotlib>=3.4.2
-    uvtools @ git+https://github.com/HERA-Team/uvtools.git
-    hera_cal @ git+https://github.com/hera-team/hera_cal
-    healvis @ git+https://github.com/rasg-affiliates/healvis
-    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging.git
-    vis_cpu>=0.4.1<1.0
+    uvtools
+    hera_cal
+    bda
+    vis_cpu>=0.4.1
 dev =
     sphinx>=1.8
     numpydoc>=0.8.0
@@ -89,14 +88,12 @@ dev =
     pytest>=3.5.1
     pytest-cov>=2.5.1
     pre-commit
-    uvtools @ git+https://github.com/HERA-Team/uvtools.git
-    healvis @ git+https://github.com/rasg-affiliates/healvis
-    hera_cal @ git+https://github.com/hera-team/hera_cal
-    bda @ git+https://github.com/HERA-Team/baseline_dependent_averaging.git
-    vis_cpu>=0.4.1<1.0
+    uvtools
+    hera_cal
+    bda
+    vis_cpu>=0.4.1
 vis =
-    vis_cpu>=0.4.1<1.0
-    healvis @ git+https://github.com/RASG-Affiliates/healvis
+    vis_cpu>=0.4.1
     pyradiosky>=0.1.2
     mpi4py
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,7 +59,7 @@ gpu =
     pycuda
     scikit-cuda
 cal =
-    hera_cal
+    hera-calibration
 docs =
     sphinx>=1.8
     nbsphinx
@@ -76,7 +76,7 @@ tests =
     pre-commit
     matplotlib>=3.4.2
     uvtools
-    hera_cal
+    hera-calibration
     bda
     vis_cpu>=0.4.1
 dev =
@@ -89,7 +89,7 @@ dev =
     pytest-cov>=2.5.1
     pre-commit
     uvtools
-    hera_cal
+    hera-calibration
     bda
     vis_cpu>=0.4.1
 vis =


### PR DESCRIPTION
This removes all the git-repo dependencies from the setup.cfg.

Most of these were easy, since they now have PyPI packages. The tricky ones were hera_gpu and healvis. For hera_gpu, I think we don't actually need it after all -- I replaced it with the underlying required packages. For healvis, it was only really needed for tests (it's an optional dependency). I've now removed it from being installed as an optional dependency (it can still be installed manually, and the module used, but it has been marked as officially deprecated). We still install it for CI tests until version 4, but following that it can be permanently removed. 