### PR TITLE
add check for clobber keyword in obsparams file

### DIFF
--- a/scripts/hera-sim-vis.py
+++ b/scripts/hera-sim-vis.py
@@ -165,10 +165,7 @@ if __name__ == "__main__":
         outfile = (
             base_path / f"{cfg_filing['outfile_name']}.{cfg_filing['output_format']}"
         )
-        if "clobber" not in cfg_filing:
-            clobber = False
-        else:
-            clobber = cfg_filing["clobber"]
+        clobber = cfg_filing.get("clobber", False)
 
         # Write output
         cns.print("Writing output... ", end="")

--- a/scripts/hera-sim-vis.py
+++ b/scripts/hera-sim-vis.py
@@ -165,10 +165,14 @@ if __name__ == "__main__":
         outfile = (
             base_path / f"{cfg_filing['outfile_name']}.{cfg_filing['output_format']}"
         )
+        if "clobber" not in cfg_filing:
+            clobber = False
+        else:
+            clobber = cfg_filing["clobber"]
 
         # Write output
         cns.print("Writing output... ", end="")
-        data_model.uvdata.write_uvh5(outfile.as_posix(), clobber=cfg_filing["clobber"])
+        data_model.uvdata.write_uvh5(outfile.as_posix(), clobber=clobber)
         cns.print("[green]:heavy_check_mark:[/]")
 
     # Sync with other workers and finalise


### PR DESCRIPTION
I modified the `hera-sim-vis.py` script to include a check for the clobber keyword in the filing parameters of the obsparam file.  If the clobber keyword is not present in the obsparams file, then clobber is set to False.  Otherwise, clobber is set to the value in the obsparam file.