### PR TITLE
fix: update VisCPU simulator wrapper to match vis_cpu v1

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -3,3 +3,21 @@ omit = hera_sim/tests/*
 
 [report]
 omit = hera_sim/tests/*
+
+# Regexes for lines to exclude from consideration
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain about missing debug-only code:
+    def __repr__
+    if self\.debug
+
+    # Don't complain if tests don't hit defensive assertion code:
+    raise AssertionError
+    raise NotImplementedError
+    except ImportError
+
+    # Don't complain if non-runnable code isn't run:
+    if 0:
+    if __name__ == .__main__.:

--- a/.github/workflows/test_suite.yaml
+++ b/.github/workflows/test_suite.yaml
@@ -20,7 +20,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest]
-        python-version: [3.7, 3.8, 3.9]
+        python-version: [3.8, 3.9, "3.10"]
     defaults:
      run:
        # Adding -l {0} ensures conda can be found properly in each step

--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,0 +1,11 @@
+[settings]
+line_length=88
+indent='    '
+skip=.tox,.venv,build,dist
+known_standard_library=setuptools,pkg_resources
+known_test=pytest
+known_first_party=vis_cpu
+sections=FUTURE,STDLIB,COMPAT,TEST,THIRDPARTY,FIRSTPARTY,LOCALFOLDER
+default_section=THIRDPARTY
+multi_line_output=3
+profile=black

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -40,3 +40,19 @@ repos:
     rev: v1.9.0
     hooks:
       - id: rst-backticks
+
+- repo: https://github.com/PyCQA/isort
+  rev: 5.10.1
+  hooks:
+  - id: isort
+
+- repo: https://github.com/asottile/pyupgrade
+  rev: v2.37.1
+  hooks:
+  - id: pyupgrade
+    args: [--py38-plus]
+
+- repo: https://github.com/asottile/setup-cfg-fmt
+  rev: v1.20.2
+  hooks:
+  - id: setup-cfg-fmt

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,21 @@ Changelog
 dev-version
 ===========
 
+v3.0.0
+======
+
+Removed
+-------
+
+- Finally removed ability to set ``use_pixel_beams`` and ``bm_pix`` on the VisCPU
+  simulator. This was removed in v1.0.0 of ``vis_cpu``.
+- Official support for py37.
+
+Internals
+---------
+
+- Added isort and pyupgrade pre-commit hooks for cleaner code.
+
 v2.3.4 [2022.06.08]
 ===================
 

--- a/config_examples/simulator.yaml
+++ b/config_examples/simulator.yaml
@@ -1,5 +1,4 @@
 simulator: VisCPU
-use_pixel_beams: false
 precision: 2
 ref_time: mean
 correct_source_positions: true

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 #
 # Configuration file for the Sphinx documentation builder.
 #

--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -10,7 +10,7 @@ try:
     DATA_PATH = Path(__file__).parent / "data"
     CONFIG_PATH = Path(__file__).parent / "config"
     __version__ = version(__name__)
-except PackageNotFoundError:
+except PackageNotFoundError:  # pragma: no cover
     # package is not installed
     pass
 

--- a/hera_sim/__init__.py
+++ b/hera_sim/__init__.py
@@ -2,9 +2,9 @@
 from pathlib import Path
 
 try:
-    from importlib.metadata import version, PackageNotFoundError
+    from importlib.metadata import PackageNotFoundError, version
 except ImportError:
-    from importlib_metadata import version, PackageNotFoundError
+    from importlib_metadata import PackageNotFoundError, version
 
 try:
     DATA_PATH = Path(__file__).parent / "data"
@@ -15,23 +15,30 @@ except PackageNotFoundError:
     pass
 
 
-from . import __yaml_constructors
-from . import adjustment
-from . import antpos
-from . import cli_utils
-from . import foregrounds
-from . import interpolators
-from . import io
-from . import noise
-from . import rfi
-from . import sigchain
-from .visibilities import simulators, load_simulator_from_yaml
-from . import eor
-from . import utils
-from . import simulate
-from . import beams
-from .simulate import Simulator
+from . import (
+    __yaml_constructors,
+    adjustment,
+    antpos,
+    beams,
+    cli_utils,
+    eor,
+    foregrounds,
+    interpolators,
+    io,
+    noise,
+    rfi,
+    sigchain,
+    simulate,
+    utils,
+)
+from .components import (
+    SimulationComponent,
+    component,
+    get_all_components,
+    get_model,
+    get_models,
+)
 from .defaults import defaults
-from .components import SimulationComponent, component
-from .components import get_all_components, get_model, get_models
-from .interpolators import Tsky, Bandpass, Beam
+from .interpolators import Bandpass, Beam, Tsky
+from .simulate import Simulator
+from .visibilities import load_simulator_from_yaml, simulators

--- a/hera_sim/__yaml_constructors.py
+++ b/hera_sim/__yaml_constructors.py
@@ -3,14 +3,12 @@ A module for generating new YAML tags for the various ``hera_sim`` interpolator 
 
 This may need to be updated if the :mod:`.interpolators` module is updated.
 """
-import yaml
+import astropy.units as u
 import inspect
 import warnings
+import yaml
 
-import astropy.units as u
-
-from . import interpolators
-from . import antpos
+from . import antpos, interpolators
 
 
 def make_interp_constructor(tag, interpolator):

--- a/hera_sim/adjustment.py
+++ b/hera_sim/adjustment.py
@@ -2,22 +2,21 @@
 
 import copy
 import logging
+import numpy as np
 import os
 import pathlib
-
-import numpy as np
-from scipy.interpolate import interp1d, RectBivariateSpline
-from warnings import warn
-
 from pyuvdata import UVData
 from pyuvdata.utils import polnum2str
+from scipy.interpolate import RectBivariateSpline, interp1d
+from warnings import warn
+
 from .simulate import Simulator
 from .utils import _listify
 
 try:
     # Import hera_cal functions.
-    from hera_cal.io import to_HERAData
     from hera_cal.abscal import get_d2m_time_map
+    from hera_cal.io import to_HERAData
     from hera_cal.utils import lst_rephase
 
     HERA_CAL = True

--- a/hera_sim/antpos.py
+++ b/hera_sim/antpos.py
@@ -5,6 +5,7 @@ dictionary whose keys refer to antenna numbers and whose values refer
 to the ENU position of the antennas.
 """
 import numpy as np
+
 from .components import component
 
 # FIXME: old docstrings state that the positions are returned in topocentric

--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -1,7 +1,8 @@
 """Module defining analytic polynomial beams."""
 import numpy as np
-from pyuvsim import AnalyticBeam
 from numpy.polynomial.chebyshev import chebval
+from pyuvsim import AnalyticBeam
+
 from . import utils
 
 

--- a/hera_sim/beams.py
+++ b/hera_sim/beams.py
@@ -383,7 +383,7 @@ class PolyBeam(AnalyticBeam):
         if self.beam_type == "power":
             # Cross-multiplying feeds, adding vector components
             pairs = [(i, j) for i in range(2) for j in range(2)]
-            power_data = np.zeros((1, 1, 4) + beam_values.shape, dtype=np.float)
+            power_data = np.zeros((1, 1, 4) + beam_values.shape, dtype=float)
             for pol_i, pair in enumerate(pairs):
                 power_data[:, :, pol_i] = (
                     interp_data[0, :, pair[0]] * np.conj(interp_data[0, :, pair[1]])

--- a/hera_sim/cli_utils.py
+++ b/hera_sim/cli_utils.py
@@ -1,11 +1,12 @@
 """Useful helper functions and argparsers for running simulations via CLI."""
 import itertools
+import numpy as np
 import os
 import warnings
-import numpy as np
+from pyuvdata import UVData
+
 from .defaults import SEASON_CONFIGS
 from .simulate import Simulator
-from pyuvdata import UVData
 
 
 def get_filing_params(config: dict):

--- a/hera_sim/components.py
+++ b/hera_sim/components.py
@@ -1,13 +1,14 @@
 """A module providing discoverability features for hera_sim."""
 
 from __future__ import annotations
+
 import re
-from abc import abstractmethod, ABCMeta
-from copy import deepcopy
-from .defaults import defaults
-from typing import Dict, Optional, Tuple, Type
-from types import new_class
+from abc import ABCMeta, abstractmethod
 from collections import defaultdict
+from copy import deepcopy
+from types import new_class
+
+from .defaults import defaults
 
 _available_components = {}
 
@@ -37,7 +38,7 @@ class SimulationComponent(metaclass=ABCMeta):
     #: Whether this systematic multiplies existing visibilities
     is_multiplicative: bool = False
 
-    _alias: Tuple[str] = tuple()
+    _alias: tuple[str] = tuple()
 
     # Keyword arguments for the Simulator to extract from the data
     _extract_kwargs = set()
@@ -81,7 +82,7 @@ class SimulationComponent(metaclass=ABCMeta):
                 cls._models[name] = cls
 
     @classmethod
-    def get_aliases(cls) -> Tuple[str]:
+    def get_aliases(cls) -> tuple[str]:
         """Get all the aliases by which this model can be identified."""
         return (cls.__name__.lower(),) + cls._alias
 
@@ -162,7 +163,7 @@ class SimulationComponent(metaclass=ABCMeta):
         return param_section.partition(section_headings[1])[0]
 
     @classmethod
-    def get_models(cls, with_aliases=False) -> Dict[str, SimulationComponent]:
+    def get_models(cls, with_aliases=False) -> dict[str, SimulationComponent]:
         """Get a dictionary of models associated with this component."""
         if with_aliases:
             return deepcopy(cls._models)
@@ -221,7 +222,7 @@ def component(cls):
     return cls
 
 
-def get_all_components(with_aliases=False) -> Dict[str, Dict[str, SimulationComponent]]:
+def get_all_components(with_aliases=False) -> dict[str, dict[str, SimulationComponent]]:
     """Get a dictionary of component names mapping to a dictionary of models."""
     return {
         cmp_name.lower(): cmp.get_models(with_aliases)
@@ -229,12 +230,12 @@ def get_all_components(with_aliases=False) -> Dict[str, Dict[str, SimulationComp
     }
 
 
-def get_models(cmp: str, with_aliases: bool = False) -> Dict[str, SimulationComponent]:
+def get_models(cmp: str, with_aliases: bool = False) -> dict[str, SimulationComponent]:
     """Get a dict of model names mapping to model classes for a particular component."""
     return get_all_components(with_aliases)[cmp.lower()]
 
 
-def get_all_models(with_aliases: bool = False) -> Dict[str, SimulationComponent]:
+def get_all_models(with_aliases: bool = False) -> dict[str, SimulationComponent]:
     """Get a dictionary of model names mapping to their classes for all possible models.
 
     See Also
@@ -250,7 +251,7 @@ def get_all_models(with_aliases: bool = False) -> Dict[str, SimulationComponent]
     return out
 
 
-def get_model(mdl: str, cmp: Optional[str] = None) -> Type[SimulationComponent]:
+def get_model(mdl: str, cmp: str | None = None) -> type[SimulationComponent]:
     """Get a particular model, based on its name.
 
     Parameters

--- a/hera_sim/data/tutorials_data/end_to_end/make_mock_catalog.py
+++ b/hera_sim/data/tutorials_data/end_to_end/make_mock_catalog.py
@@ -1,11 +1,11 @@
 """Script for making a mock point source catalog."""
-from pyuvsim.simsetup import initialize_uvdata_from_params
-from astropy.coordinates import EarthLocation, Latitude, Longitude
-from astropy import units
-import numpy as np
-from pyuvsim import create_mock_catalog
-from pyradiosky import SkyModel
 import argparse
+import numpy as np
+from astropy import units
+from astropy.coordinates import EarthLocation, Latitude, Longitude
+from pyradiosky import SkyModel
+from pyuvsim import create_mock_catalog
+from pyuvsim.simsetup import initialize_uvdata_from_params
 
 
 def make_mock_catalog(

--- a/hera_sim/defaults.py
+++ b/hera_sim/defaults.py
@@ -1,11 +1,11 @@
 """Module for interfacing with package-wide default parameters."""
 
-import yaml
-import inspect
 import functools
+import inspect
 import warnings
-
+import yaml
 from os import path
+
 from .config import CONFIG_PATH
 
 SEASON_CONFIGS = {
@@ -20,7 +20,7 @@ class _Singleton(type):
 
     def __call__(cls, *args, **kwargs):
         if cls not in cls._instances:
-            cls._instances[cls] = super(_Singleton, cls).__call__(*args, **kwargs)
+            cls._instances[cls] = super().__call__(*args, **kwargs)
         return cls._instances[cls]
 
 
@@ -198,7 +198,7 @@ class Defaults(metaclass=_Singleton):
                 self._config_name = config
                 config = SEASON_CONFIGS[config]
             # load in the raw configuration
-            with open(config, "r") as conf:
+            with open(config) as conf:
                 self._raw_config = yaml.load(conf.read(), Loader=yaml.FullLoader)
         elif isinstance(config, dict):
             # set the raw configuration dictionary to config
@@ -290,7 +290,7 @@ class Defaults(metaclass=_Singleton):
             )
             for param, flag in flags.items():
                 if flag:
-                    warning += "{}\n".format(param)
+                    warning += f"{param}\n"
             warning += (
                 "Please check your configuration, as only the last "
                 "value specified for each parameter will be used."

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -7,9 +7,10 @@ a visibility appropriate for the given baseline.
 """
 
 import numpy as np
-from .components import component
-from . import utils
 from typing import Optional
+
+from . import utils
+from .components import component
 
 
 @component

--- a/hera_sim/interpolators.py
+++ b/hera_sim/interpolators.py
@@ -1,10 +1,11 @@
 """This module provides interfaces to different interpolation classes."""
-import warnings
 import numpy as np
+import warnings
 from cached_property import cached_property
-from scipy.interpolate import RectBivariateSpline, interp1d
-from hera_sim import DATA_PATH
 from os import path
+from scipy.interpolate import RectBivariateSpline, interp1d
+
+from hera_sim import DATA_PATH
 
 INTERP_OBJECTS = {
     "1d": (

--- a/hera_sim/io.py
+++ b/hera_sim/io.py
@@ -1,14 +1,15 @@
 """Methods for input/output of data."""
-import os
-import warnings
 import numpy as np
+import os
 import pyuvdata
+import re
+import warnings
 from pyuvdata import UVData
 from pyuvsim.simsetup import initialize_uvdata_from_keywords
-from .defaults import _defaults
-from . import DATA_PATH
-import re
 from typing import Dict, Sequence
+
+from . import DATA_PATH
+from .defaults import _defaults
 
 HERA_LAT_LON_ALT = np.load(DATA_PATH / "HERA_LAT_LON_ALT.npy")
 

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -1,13 +1,12 @@
 """Models of thermal noise."""
 
-import warnings
 import astropy.units as u
 import numpy as np
+import warnings
 
+from . import DATA_PATH, utils
 from .components import component
-from . import DATA_PATH
 from .interpolators import Tsky
-from . import utils
 
 # to minimize breaking changes
 HERA_Tsky_mdl = {

--- a/hera_sim/rfi.py
+++ b/hera_sim/rfi.py
@@ -1,10 +1,11 @@
 """Models of radio frequency interference."""
-import warnings
-import numpy as np
 import astropy.units as u
+import numpy as np
+import warnings
+from pathlib import Path
+
 from .components import component
 from .utils import _listify
-from pathlib import Path
 
 
 @component

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -6,16 +6,13 @@ example bandpass gains, reflections and cross-talk.
 
 import numpy as np
 import warnings
-from typing import Dict, Optional, Sequence, Tuple, Union
-
 from astropy import constants
 from scipy import stats
 from scipy.signal import blackmanharris
+from typing import Dict, Optional, Sequence, Tuple, Union
 
-from . import interpolators
-from . import utils
+from . import DATA_PATH, interpolators, utils
 from .components import component
-from . import DATA_PATH
 from .defaults import _defaults
 
 

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -6,25 +6,22 @@ For detailed instructions on how to manage a simulation using the
 :class:`Simulator`, please refer to the tutorials.
 """
 
-from cached_property import cached_property
 import functools
 import inspect
+import numpy as np
+import time
 import warnings
 import yaml
-import time
-from pathlib import Path
-from deprecation import deprecated
-
-import numpy as np
-from pyuvdata import UVData
 from astropy import constants as const
-from typing import Type, Union, Tuple, Sequence, Optional, Dict
+from cached_property import cached_property
+from deprecation import deprecated
+from pathlib import Path
+from pyuvdata import UVData
+from typing import Dict, Optional, Sequence, Tuple, Type, Union
 
-from . import io
-from . import utils
-from .defaults import defaults
-from . import __version__
+from . import __version__, io, utils
 from .components import SimulationComponent, get_model, list_all_components
+from .defaults import defaults
 
 _add_depr = deprecated(
     deprecated_in="1.0", removed_in="2.0", details="Use the :meth:`add` method instead."
@@ -542,11 +539,11 @@ class Simulator:
 
         # read the simulation file if provided
         if sim_file is not None:
-            with open(sim_file, "r") as config:
+            with open(sim_file) as config:
                 try:
                     sim_params = yaml.load(config.read(), Loader=yaml.FullLoader)
                 except Exception:
-                    raise IOError("The configuration file was not able to be loaded.")
+                    raise OSError("The configuration file was not able to be loaded.")
 
         # loop over the entries in the configuration dictionary
         for component, params in sim_params.items():

--- a/hera_sim/tests/conftest.py
+++ b/hera_sim/tests/conftest.py
@@ -1,6 +1,7 @@
 import pytest
-from astropy.utils import iers
+
 from astropy.time import Time
+from astropy.utils import iers
 
 
 @pytest.fixture(autouse=True, scope="session")

--- a/hera_sim/tests/test_adjustment.py
+++ b/hera_sim/tests/test_adjustment.py
@@ -1,21 +1,18 @@
 """Test the various simulation adjustment tools."""
 
+import pytest
+
 import copy
 import itertools
 import logging
-import os
-import pytest
-
-from astropy import units
-from scipy import stats
 import numpy as np
-
-from hera_sim import adjustment
-from hera_sim import antpos
-from hera_sim import interpolators
-from hera_sim import Simulator
+import os
+from astropy import units
 from pyuvdata import UVData
 from pyuvdata.utils import antnums_to_baseline
+from scipy import stats
+
+from hera_sim import Simulator, adjustment, antpos, interpolators
 
 # For use later when simulating foregrounds.
 Tsky_mdl = interpolators.Tsky(datafile="HERA_Tsky_Reformatted.npz")

--- a/hera_sim/tests/test_antpos.py
+++ b/hera_sim/tests/test_antpos.py
@@ -1,5 +1,6 @@
-from hera_sim import antpos
 import numpy as np
+
+from hera_sim import antpos
 
 
 def check_ant_labels(Nants_expected, ants):

--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -1,21 +1,23 @@
 import pytest
+
+import astropy_healpix.healpy as hp
+import copy
 import numpy as np
-from hera_sim.visibilities import VisCPU, ModelData, VisibilitySimulation
+from astropy import units
+from astropy.coordinates import Latitude, Longitude
+from pyradiosky import SkyModel
+from typing import List
+
 from hera_sim import io
 from hera_sim.beams import (
     PerturbedPolyBeam,
     PolyBeam,
-    efield_to_pstokes,
     ZernikeBeam,
+    efield_to_pstokes,
     stokes_matrix,
 )
 from hera_sim.defaults import defaults
-from pyradiosky import SkyModel
-from astropy import units
-from astropy.coordinates import Longitude, Latitude
-import astropy_healpix.healpy as hp
-from typing import List
-import copy
+from hera_sim.visibilities import ModelData, VisCPU, VisibilitySimulation
 
 np.seterr(invalid="ignore")
 

--- a/hera_sim/tests/test_beams.py
+++ b/hera_sim/tests/test_beams.py
@@ -61,36 +61,7 @@ def evaluate_polybeam(polybeam):
     az = -np.arctan2(m, L)
     za = np.pi / 2 - np.arcsin(n)
 
-    freqs = np.array(
-        [
-            1.00e08,
-            1.04e08,
-            1.08e08,
-            1.12e08,
-            1.16e08,
-            1.20e08,
-            1.24e08,
-            1.28e08,
-            1.32e08,
-            1.36e08,
-            1.40e08,
-            1.44e08,
-            1.48e08,
-            1.52e08,
-            1.56e08,
-            1.60e08,
-            1.64e08,
-            1.68e08,
-            1.72e08,
-            1.76e08,
-            1.80e08,
-            1.84e08,
-            1.88e08,
-            1.92e08,
-            1.96e08,
-            2.00e08,
-        ]
-    )
+    freqs = np.arange(1e8, 2.01e8, 0.04e8)
 
     eval_beam = polybeam.interp(az, za, freqs)
 
@@ -250,31 +221,21 @@ class TestPerturbedPolyBeam:
         rvals = np.linspace(0.0, 180.0, 31, dtype=int)
 
         rotations = np.zeros(rvals.size)
-        # pix_results = np.zeros(rvals.size)
         calc_results = np.zeros(rvals.size)
         for i, r in enumerate(rvals):
             beams = self.get_perturbed_beams(r, power_beam=True)
-            # pix_result = run_sim(antennas, sources, beams, use_pixel_beams=True)
 
             # Direct beam calculation - no pixel beams
             calc_result = run_sim(antennas, sources, beams)
 
             rotations[i] = r
-            # pix_results[i] = pix_result
             calc_results[i] = calc_result
 
-        # Check that the maximum difference between pixel beams/direct calculation
-        # cases is no more than 5%. This shows the direct calculation of the beam
-        # tracks the pixel beam interpolation. They won't be exactly the same.
-        # np.testing.assert_allclose(pix_results, calc_results, rtol=0.05)
-
         # Check that rotations 0 and 180 produce the same values.
-        # assert pix_results[0] == pytest.approx(pix_results[-1], abs=1e-8)
         assert calc_results[0] == pytest.approx(calc_results[-1], abs=1e-8)
 
         # Check that the values are not all the same. Shouldn't be, due to
         # elliptic beam.
-        # assert np.min(pix_results) != pytest.approx(np.max(pix_results), abs=0.1)
         assert np.min(calc_results) != pytest.approx(np.max(calc_results), abs=0.1)
 
     def test_power_beam(self, antennas, sources):
@@ -514,17 +475,6 @@ class TestZernikeBeam:
             ],
         )
         return [ZernikeBeam(**cfg_beam)]
-
-    # def test_sim_with_pixels(self, beams, antennas, sources):
-
-    #     # Calculate visibilities using pixel and interpolated beams
-    #     # pix_result = run_sim(antennas, sources, beams, use_pixel_beams=True)
-    #     calc_result = run_sim(antennas, sources, beams)
-
-    #     # Check that the maximum difference between pixel beams/direct calculation
-    #     # cases is no more than 5%. This shows the direct calculation of the beam
-    #     # tracks the pixel beam interpolation. They won't be exactly the same.
-    #     np.testing.assert_allclose(pix_result, calc_result, rtol=0.05)
 
     def test_equality(self, beams):
         # Check basic methods

--- a/hera_sim/tests/test_cli_utils.py
+++ b/hera_sim/tests/test_cli_utils.py
@@ -1,15 +1,14 @@
 """Test different utilities for the command-line interface."""
 
-import os
 import pytest
 
-from astropy import units
 import numpy as np
-
-from hera_sim import cli_utils
-from hera_sim import Simulator
-from hera_sim.sigchain import gen_gains
+import os
+from astropy import units
 from pyuvdata import UVCal
+
+from hera_sim import Simulator, cli_utils
+from hera_sim.sigchain import gen_gains
 
 
 @pytest.fixture

--- a/hera_sim/tests/test_compare_pyuvsim.py
+++ b/hera_sim/tests/test_compare_pyuvsim.py
@@ -1,20 +1,18 @@
 """Compare vis_cpu with pyuvsim visibilities."""
-import numpy as np
 import pytest
 
-from pyuvsim import uvsim, simsetup, AnalyticBeam
+import copy
+import numpy as np
+from astropy.coordinates import Latitude, Longitude
+from astropy.time import Time
+from astropy.units import Quantity
+from pyradiosky import SkyModel
+from pyuvsim import AnalyticBeam, simsetup, uvsim
 from pyuvsim.telescope import BeamList
 
-from hera_sim.beams import PolyBeam
-from hera_sim.visibilities import VisCPU, ModelData, VisibilitySimulation
 from hera_sim import io
-
-from astropy.coordinates import Latitude, Longitude
-from astropy.units import Quantity
-from astropy.time import Time
-
-from pyradiosky import SkyModel
-import copy
+from hera_sim.beams import PolyBeam
+from hera_sim.visibilities import ModelData, VisCPU, VisibilitySimulation
 
 nfreq = 3
 ntime = 20

--- a/hera_sim/tests/test_compare_pyuvsim.py
+++ b/hera_sim/tests/test_compare_pyuvsim.py
@@ -171,7 +171,6 @@ def test_compare_viscpu_with_pyuvsim(uvdata_allpols, nsource, beam_type, polariz
     simulator = VisCPU(
         ref_time=Time("2018-08-31T04:02:30.11", format="isot", scale="utc"),
         use_gpu=False,
-        use_pixel_beams=False,
     )
 
     # TODO: if we update the PolyBeam API so that it doesn't *require* 2 feeds,

--- a/hera_sim/tests/test_components.py
+++ b/hera_sim/tests/test_components.py
@@ -1,11 +1,9 @@
-from hera_sim.noise import Noise, ThermalNoise
-from hera_sim.components import (
-    component,
-    get_model,
-    get_models,
-)
 import pytest
+
 import numpy as np
+
+from hera_sim.components import component, get_model, get_models
+from hera_sim.noise import Noise, ThermalNoise
 
 
 def test_get_component():

--- a/hera_sim/tests/test_defaults.py
+++ b/hera_sim/tests/test_defaults.py
@@ -1,11 +1,13 @@
-from os.path import join
-import numpy as np
 import pytest
+
+import numpy as np
+from os.path import join
 from warnings import catch_warnings
-from hera_sim.defaults import defaults
+
 from hera_sim.config import CONFIG_PATH
+from hera_sim.defaults import defaults
+from hera_sim.interpolators import Beam, Tsky
 from hera_sim.sigchain import gen_bandpass
-from hera_sim.interpolators import Tsky, Beam
 
 
 def test_config_swap():

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -1,6 +1,8 @@
 import pytest
-from hera_sim import eor
+
 import numpy as np
+
+from hera_sim import eor
 
 
 @pytest.fixture(scope="function")

--- a/hera_sim/tests/test_foregrounds.py
+++ b/hera_sim/tests/test_foregrounds.py
@@ -1,11 +1,12 @@
-from contextlib import ExitStack as does_not_raise
 import pytest
-from hera_sim import foregrounds
-from hera_sim import DATA_PATH
-from hera_sim.interpolators import Beam, Tsky
-from astropy import units
+
 import numpy as np
+from astropy import units
+from contextlib import ExitStack as does_not_raise
 from uvtools.utils import FFT, fourier_freqs
+
+from hera_sim import DATA_PATH, foregrounds
+from hera_sim.interpolators import Beam, Tsky
 
 
 @pytest.fixture(scope="function")

--- a/hera_sim/tests/test_interpolators.py
+++ b/hera_sim/tests/test_interpolators.py
@@ -1,9 +1,9 @@
-import numpy as np
 import pytest
 
+import numpy as np
 from scipy.interpolate import RectBivariateSpline, interp1d
-from hera_sim.interpolators import Tsky, Beam, Bandpass, _check_path, _read
 
+from hera_sim.interpolators import Bandpass, Beam, Tsky, _check_path, _read
 
 INTERPOLATORS = {"beam": Beam, "bandpass": Bandpass, "tsky": Tsky}
 

--- a/hera_sim/tests/test_io.py
+++ b/hera_sim/tests/test_io.py
@@ -1,4 +1,5 @@
 import pytest
+
 import numpy as np
 
 from hera_sim import io
@@ -84,11 +85,11 @@ def test_deprecation_warning(
 def test_chunker_using_ref_files(sample_uvd, tmp_path):
     io.chunk_sim_and_save(sample_uvd, tmp_path, Nint_per_file=5, prefix="zen")
     ref_files = sorted(
-        [tmp_path / f for f in tmp_path.iterdir() if f.name.startswith("zen")]
+        tmp_path / f for f in tmp_path.iterdir() if f.name.startswith("zen")
     )
     io.chunk_sim_and_save(sample_uvd, tmp_path, ref_files=ref_files, prefix="hor")
     new_files = sorted(
-        [tmp_path / f for f in tmp_path.iterdir() if f.name.startswith("hor")]
+        tmp_path / f for f in tmp_path.iterdir() if f.name.startswith("hor")
     )
     print([f.name[4:] for f in ref_files])
     print([f.name[4:] for f in new_files])

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -1,13 +1,12 @@
-from contextlib import contextmanager
 import pytest
 
 import numpy as np
 from astropy import units
+from contextlib import contextmanager
 
-from hera_sim import noise, utils
-from hera_sim import DATA_PATH
-from hera_sim.interpolators import Beam
+from hera_sim import DATA_PATH, noise, utils
 from hera_sim.defaults import defaults
+from hera_sim.interpolators import Beam
 
 # Ensure that defaults aren't subtly overwritten.
 defaults.deactivate()

--- a/hera_sim/tests/test_rfi.py
+++ b/hera_sim/tests/test_rfi.py
@@ -1,8 +1,8 @@
 import pytest
+
 import numpy as np
 
-from hera_sim import rfi
-from hera_sim import DATA_PATH
+from hera_sim import DATA_PATH, rfi
 
 
 @pytest.fixture(scope="function")

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -1,10 +1,11 @@
 import pytest
-from hera_sim import sigchain, noise, foregrounds
-from hera_sim.interpolators import Bandpass, Beam
-from hera_sim import DATA_PATH
-import uvtools
+
 import numpy as np
-from astropy import units, constants
+import uvtools
+from astropy import constants, units
+
+from hera_sim import DATA_PATH, foregrounds, noise, sigchain
+from hera_sim.interpolators import Bandpass, Beam
 
 np.random.seed(0)
 

--- a/hera_sim/tests/test_sim_red_data.py
+++ b/hera_sim/tests/test_sim_red_data.py
@@ -1,8 +1,10 @@
 import pytest
-from hera_cal import redcal as om
+
 import numpy as np
-from hera_sim.antpos import linear_array
+from hera_cal import redcal as om
+
 from hera_sim import vis
+from hera_sim.antpos import linear_array
 
 
 @pytest.fixture(scope="function")

--- a/hera_sim/tests/test_simulate_cli.py
+++ b/hera_sim/tests/test_simulate_cli.py
@@ -1,10 +1,9 @@
 """Basic tests of the hera-sim-simulate script."""
 
-import os
 import pytest
 
 import numpy as np
-
+import os
 from pyuvdata import UVCal, UVData
 
 

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -4,24 +4,23 @@ check for correctness of individual models, as they should be tested
 elsewhere.
 """
 
-import copy
-import itertools
-import tempfile
-import os
-import yaml
-from deprecation import fail_if_not_removed
-import numpy as np
 import pytest
 
-from hera_sim.foregrounds import DiffuseForeground, diffuse_foreground
-from hera_sim.noise import HERA_Tsky_mdl
-from hera_sim.antpos import hex_array
-from hera_sim import DATA_PATH, CONFIG_PATH
-from hera_sim.defaults import defaults
-from hera_sim.interpolators import Beam
-from hera_sim import Simulator, component
+import copy
+import itertools
+import numpy as np
+import os
+import tempfile
+import yaml
+from deprecation import fail_if_not_removed
 from pyuvdata import UVData
 
+from hera_sim import CONFIG_PATH, DATA_PATH, Simulator, component
+from hera_sim.antpos import hex_array
+from hera_sim.defaults import defaults
+from hera_sim.foregrounds import DiffuseForeground, diffuse_foreground
+from hera_sim.interpolators import Beam
+from hera_sim.noise import HERA_Tsky_mdl
 
 beamfile = os.path.join(DATA_PATH, "HERA_H1C_BEAM_POLY.npy")
 omega_p = Beam(beamfile)

--- a/hera_sim/tests/test_utils.py
+++ b/hera_sim/tests/test_utils.py
@@ -1,10 +1,9 @@
-import numpy as np
 import pytest
 
+import numpy as np
 from astropy import units
 
-from hera_sim import utils
-from hera_sim import DATA_PATH
+from hera_sim import DATA_PATH, utils
 from hera_sim.interpolators import Beam
 
 

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -14,7 +14,6 @@ from hera_sim.visibilities import (
     VisibilitySimulation,
     ModelData,
     UVSim,
-    vis_cpu,
     load_simulator_from_yaml,
 )
 from hera_sim.beams import PolyBeam
@@ -46,7 +45,6 @@ if HAVE_GPU:
 
 np.random.seed(0)
 NTIMES = 10
-BM_PIX = 31
 NPIX = 12 * 16**2
 NFREQ = 5
 
@@ -505,35 +503,6 @@ def test_comparison(simulator, uvdata2, sky_model, beam_model):
     np.testing.assert_allclose(v0, v1, rtol=0.05)
 
 
-def test_vis_cpu_pol_gpu(uvdata_linear):
-    old = vis_cpu.HAVE_GPU
-
-    vis_cpu.HAVE_GPU = True
-
-    uvdata_linear.polarization_array = [-8, -7, -6, -5]
-    beam = PolyBeam(polarized=True)
-
-    sky_model = make_point_sky(
-        uvdata_linear,
-        ra=np.linspace(0, 2 * np.pi, 8) * rad,
-        dec=uvdata_linear.telescope_location_lat_lon_alt[0] * np.ones(8) * rad,
-        align=False,
-    )
-
-    simulator = VisCPU(use_gpu=True)
-
-    with pytest.raises(RuntimeError):
-        VisibilitySimulation(
-            data_model=ModelData(
-                uvdata=uvdata_linear, sky_model=sky_model, beams=[beam]
-            ),
-            simulator=simulator,
-            n_side=2**4,
-        )
-
-    vis_cpu.HAVE_GPU = old
-
-
 @pytest.mark.parametrize("simulator", SIMULATORS)
 @pytest.mark.parametrize("order", ["time", "baseline", "ant1", "ant2"])
 @pytest.mark.parametrize("conj", ["ant1<ant2", "ant2<ant1"])
@@ -724,7 +693,6 @@ def test_load_from_yaml(tmpdir):
 
     assert sim2.ref_time == simulator.ref_time
     assert sim2.diffuse_ability == simulator.diffuse_ability
-    assert sim2.use_pixel_beams == simulator.use_pixel_beams
 
 
 def test_bad_load(tmpdir):

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -1,27 +1,29 @@
+import pytest
+
 import astropy_healpix as aph
+import copy
 import healvis
 import numpy as np
-import pytest
-from astropy.units import sday, rad
+from astropy import time as apt
 from astropy import units
+from astropy.coordinates.angles import Latitude, Longitude
+from astropy.units import rad, sday
+from pathlib import Path
+from pyradiosky import SkyModel
 from pyuvsim.analyticbeam import AnalyticBeam
 from pyuvsim.telescope import BeamConsistencyError
-from vis_cpu import HAVE_GPU
-from hera_sim.defaults import defaults
+
 from hera_sim import io
+from hera_sim.beams import PolyBeam
+from hera_sim.defaults import defaults
 from hera_sim.visibilities import (
-    VisCPU,
-    VisibilitySimulation,
     ModelData,
     UVSim,
+    VisCPU,
+    VisibilitySimulation,
     load_simulator_from_yaml,
 )
-from hera_sim.beams import PolyBeam
-from pyradiosky import SkyModel
-from astropy.coordinates.angles import Latitude, Longitude
-from astropy import time as apt
-import copy
-from pathlib import Path
+from vis_cpu import HAVE_GPU
 
 SIMULATORS = (VisCPU, UVSim)
 
@@ -134,7 +136,7 @@ def test_healvis_beam_obsparams(tmpdir):
     pytest.importorskip("healvis")
     direc = tmpdir.mkdir("test_healvis_beam")
 
-    with open(Path(__file__).parent / "testdata" / "healvis_catalog.txt", "r") as fl:
+    with open(Path(__file__).parent / "testdata" / "healvis_catalog.txt") as fl:
         txt = fl.read()
 
     with open(direc.join("catalog.txt"), "w") as fl:

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -207,6 +207,13 @@ def test_JD(uvdata, uvdataJD, sky_model):
     assert not np.allclose(sim1, sim2, atol=0.1)
 
 
+def test_vis_cpu_estimate_memory(uvdata, uvdataJD, sky_model):
+    model_data = ModelData(sky_model=sky_model, uvdata=uvdata)
+    vis = VisCPU()
+    mem = vis.estimate_memory(model_data)
+    assert mem > 0
+
+
 @pytest.fixture
 def uvdata2():
     defaults.set("h1c")

--- a/hera_sim/tests/test_yaml_constructors.py
+++ b/hera_sim/tests/test_yaml_constructors.py
@@ -1,8 +1,8 @@
 """Module for testing the various new YAML tags in this package."""
 
 import pytest
-import yaml
 
+import yaml
 from astropy.units.quantity import Quantity
 
 
@@ -22,7 +22,7 @@ def test_astropy_units_constructor(tmp_path):
                 units: rad
                 """
         )
-    with open(tfile, "r") as f:
+    with open(tfile) as f:
         mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
     for value in mydict.values():
         assert isinstance(value, Quantity)
@@ -39,7 +39,7 @@ def test_astropy_constructor_nonetypes(tmp_path):
                 value: 1
                 """
         )
-    with open(tfile, "r") as f:
+    with open(tfile) as f:
         mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
     for value in mydict.values():
         assert value is None
@@ -55,6 +55,6 @@ def bad_astropy_units(tmp_path):
                 units: bad_units"""
         )
     with pytest.raises(ValueError) as err:
-        with open(tfile, "r") as f:
+        with open(tfile) as f:
             yaml.load(f.read(), Loader=yaml.FullLoader)
     assert "Please check your configuration" in err.value.args[0]

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -1,10 +1,11 @@
 """Utility module."""
-import numpy as np
 import astropy.constants as const
 import astropy.units as u
-from scipy.interpolate import RectBivariateSpline
-from typing import Sequence, Optional, Tuple, Union
+import numpy as np
 import warnings
+from scipy.interpolate import RectBivariateSpline
+from typing import Optional, Sequence, Tuple, Union
+
 from .interpolators import Beam
 
 

--- a/hera_sim/vis.py
+++ b/hera_sim/vis.py
@@ -1,7 +1,8 @@
 """Functions for producing white-noise redundant visibilities."""
 import numpy as np
-from . import noise
 from copy import deepcopy
+
+from . import noise
 
 DEFAULT_LSTS = np.linspace(0, 2 * np.pi, 10000, endpoint=False)
 DEFAULT_FQS = np.linspace(0.1, 0.2, 1024, endpoint=False)

--- a/hera_sim/visibilities/__init__.py
+++ b/hera_sim/visibilities/__init__.py
@@ -8,16 +8,16 @@ temperature fields, rectilinear co-ordinates, spherical co-ordinates, healpix
 maps etc. This package intends to unify the interfaces of these various kinds
 of simulators.
 """
+from .pyuvsim_wrapper import UVSim
 from .simulators import (
-    VisibilitySimulator,
-    VisibilitySimulation,
     ModelData,
+    VisibilitySimulation,
+    VisibilitySimulator,
     load_simulator_from_yaml,
 )
 
 # Registered Simulators
 
-from .pyuvsim_wrapper import UVSim
 
 try:
     from .vis_cpu import VisCPU

--- a/hera_sim/visibilities/healvis_wrapper.py
+++ b/hera_sim/visibilities/healvis_wrapper.py
@@ -38,6 +38,8 @@ class HealVis(VisibilitySimulator):
 
     point_source_ability = False
     diffuse_ability = True
+    _functions_to_profile = (hv.observatory.Observatory.make_visibilities,)
+
     __version__ = hv.__version__
 
     def __init__(self, fov=180, nprocesses=1, sky_ref_chan=0):

--- a/hera_sim/visibilities/healvis_wrapper.py
+++ b/hera_sim/visibilities/healvis_wrapper.py
@@ -2,20 +2,19 @@
 from __future__ import division
 
 import numpy as np
-
 import pyuvsim
 import warnings
-from .simulators import VisibilitySimulator, ModelData, SkyModel
-
 from astropy import constants as cnst
 from astropy import units
 
+from .simulators import ModelData, SkyModel, VisibilitySimulator
+
 try:
-    from healvis.beam_model import AnalyticBeam
-    from healvis.simulator import setup_observatory_from_uvdata
-    from healvis import sky_model as hvsm
-    from healvis.observatory import Observatory
     import healvis as hv
+    from healvis import sky_model as hvsm
+    from healvis.beam_model import AnalyticBeam
+    from healvis.observatory import Observatory
+    from healvis.simulator import setup_observatory_from_uvdata
 
     HAVE_HEALVIS = True
 except ImportError:

--- a/hera_sim/visibilities/pyuvsim_wrapper.py
+++ b/hera_sim/visibilities/pyuvsim_wrapper.py
@@ -15,6 +15,8 @@ class UVSim(VisibilitySimulator):
         If True, don't print anything.
     """
 
+    _functions_to_profile = (pyuvsim.uvsim.run_uvdata_uvsim,)
+
     def __init__(self, quiet: bool = False):
         self.quiet = quiet
 

--- a/hera_sim/visibilities/pyuvsim_wrapper.py
+++ b/hera_sim/visibilities/pyuvsim_wrapper.py
@@ -1,8 +1,9 @@
 """Wrapper for the pyuvsim simulator."""
-import pyuvsim
-from .simulators import VisibilitySimulator, ModelData
 import numpy as np
+import pyuvsim
 import warnings
+
+from .simulators import ModelData, VisibilitySimulator
 
 
 class UVSim(VisibilitySimulator):

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -377,6 +377,9 @@ class VisibilitySimulator(metaclass=ABCMeta):
     #: maps directly.
     diffuse_ability = False
 
+    #: Any underlying functions that are called and we may want to do profiling on.
+    _functions_to_profile = ()
+
     __version__ = "unknown"
 
     @abstractmethod
@@ -410,6 +413,17 @@ class VisibilitySimulator(metaclass=ABCMeta):
         complex than simply setting parameters from the dictionary.
         """
         return cls(**cfg)
+
+    def estimate_memory(self, data_model: ModelData) -> float:
+        """Estimate the memory usage of the simulator in GB.
+
+        This is used to estimate the amount of memory needed to run the simulator.
+
+        .. note:: the default method is very much a lower bound -- just the size of the
+          output visibilities. Each individual simulator may or may not implement a
+          more accurate estimate.
+        """
+        return data_model.uvdata.data_array.nbytes / 1024**3
 
 
 def load_simulator_from_yaml(config: Path | str) -> VisibilitySimulator:

--- a/hera_sim/visibilities/simulators.py
+++ b/hera_sim/visibilities/simulators.py
@@ -1,28 +1,30 @@
 """Module defining a high-level visibility simulator wrapper."""
 from __future__ import annotations
 
+import astropy_healpix as aph
+import importlib
 import numpy as np
-from cached_property import cached_property
-from pyuvsim import analyticbeam as ab, BeamList
-from pyuvsim.simsetup import (
-    initialize_uvdata_from_params,
-    initialize_catalog_from_params,
-    uvdata_to_telescope_config,
-    _complete_uvdata,
-)
-from os import path
+import yaml
 from abc import ABCMeta, abstractmethod
 from astropy import units
-from pyuvdata import UVData, UVBeam
-from typing import List, Dict, Union, Sequence
-from pyradiosky import SkyModel
-from pathlib import Path
+from cached_property import cached_property
 from dataclasses import dataclass
-import astropy_healpix as aph
+from os import path
+from pathlib import Path
+from pyradiosky import SkyModel
+from pyuvdata import UVBeam, UVData
+from pyuvsim import BeamList
+from pyuvsim import analyticbeam as ab
+from pyuvsim.simsetup import (
+    _complete_uvdata,
+    initialize_catalog_from_params,
+    initialize_uvdata_from_params,
+    uvdata_to_telescope_config,
+)
+from typing import List, Sequence, Union
+
 from .. import __version__
 from .. import visibilities as vis
-import importlib
-import yaml
 
 BeamListType = Union[BeamList, List[Union[ab.AnalyticBeam, UVBeam]]]
 
@@ -68,7 +70,7 @@ class ModelData:
         *,
         uvdata: UVData | str | Path,
         sky_model: SkyModel,
-        beam_ids: Dict[str, int] | Sequence[int] | None = None,
+        beam_ids: dict[str, int] | Sequence[int] | None = None,
         beams: BeamListType | None = None,
         normalize_beams: bool = False,
     ):
@@ -133,9 +135,9 @@ class ModelData:
 
     def _process_beam_ids(
         self,
-        beam_ids: Dict[str, int] | np.typing.ArrayLike[int] | None,
+        beam_ids: dict[str, int] | np.typing.ArrayLike[int] | None,
         beams: BeamList,
-    ) -> Dict[str, int]:
+    ) -> dict[str, int]:
         # beam ids maps antenna name to INDEX of the beam in the beam list.
 
         # Set the beam_ids.
@@ -390,7 +392,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
     def from_yaml(cls, yaml_config: dict | str | Path) -> VisibilitySimulator:
         """Generate the simulator from a YAML file or dictionary."""
         if not isinstance(yaml_config, dict):
-            with open(yaml_config, "r") as fl:
+            with open(yaml_config) as fl:
                 yaml_config = yaml.safe_load(fl)
 
         # In general, we allow to specify which simulator to use in the config,
@@ -412,7 +414,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
 
 def load_simulator_from_yaml(config: Path | str) -> VisibilitySimulator:
     """Construct a visibility simulator from a YAML file."""
-    with open(config, "r") as fl:
+    with open(config) as fl:
         cfg = yaml.safe_load(fl)
 
     simulator_cls = cfg.pop("simulator")

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -172,8 +172,8 @@ class VisCPU(VisibilitySimulator):
         """
         bm = data_model.beams[0]
         nt = len(data_model.lsts)
-        nax = len(bm.Naxes_vec)
-        nfd = len(bm.Nfeeds)
+        nax = bm.Naxes_vec
+        nfd = bm.Nfeeds
         nant = len(data_model.uvdata.antenna_names)
         nsrc = len(data_model.sky_model.ra)
         nbeam = len(data_model.beams)

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -1,19 +1,19 @@
 """Wrapper for vis_cpu visibility simulator."""
-from __future__ import division, annotations
-import numpy as np
-import itertools
-
-from .simulators import VisibilitySimulator, ModelData
-from typing import Tuple, Union, Optional, List
+from __future__ import annotations, division
 
 import astropy.units as u
-from astropy.time import Time
+import itertools
+import numpy as np
 from astropy.coordinates import EarthLocation
-
-from vis_cpu import vis_cpu, vis_gpu, HAVE_GPU, __version__
-from vis_cpu import conversions as convs
+from astropy.time import Time
 from pyuvdata import UVData
 from pyuvdata import utils as uvutils
+
+from vis_cpu import HAVE_GPU, __version__
+from vis_cpu import conversions as convs
+from vis_cpu import vis_cpu, vis_gpu
+
+from .simulators import ModelData, VisibilitySimulator
 
 
 class VisCPU(VisibilitySimulator):
@@ -71,7 +71,7 @@ class VisCPU(VisibilitySimulator):
         precision: int = 1,
         use_gpu: bool = False,
         mpi_comm=None,
-        ref_time: Optional[Union[str, Time]] = None,
+        ref_time: str | Time | None = None,
         correct_source_positions: bool | None = None,
     ):
         assert precision in {1, 2}
@@ -157,9 +157,9 @@ class VisCPU(VisibilitySimulator):
     def correct_point_source_pos(
         self,
         data_model: ModelData,
-        obstime: Optional[Union[str, Time]] = None,
+        obstime: str | Time | None = None,
         frame: str = "icrs",
-    ) -> Tuple[np.ndarray, np.ndarray]:
+    ) -> tuple[np.ndarray, np.ndarray]:
         """Apply correction to source RA and Dec positions to improve accuracy.
 
         This uses an astropy-based coordinate correction, computed for a single
@@ -345,7 +345,7 @@ class VisCPU(VisibilitySimulator):
 
                 visfull[indx, p] = vis_here
 
-    def _get_req_pols(self, uvdata, uvbeam, polarized: bool) -> List[Tuple[int, int]]:
+    def _get_req_pols(self, uvdata, uvbeam, polarized: bool) -> list[tuple[int, int]]:
         if not polarized:
             return [(0, 0)]
 

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -173,8 +173,8 @@ class VisCPU(VisibilitySimulator):
         """
         bm = data_model.beams[0]
         nt = len(data_model.lsts)
-        nax = bm.Naxes_vec
-        nfd = bm.Nfeeds
+        nax = getattr(bm, "Naxes_vec", 1)
+        nfd = getattr(bm, "Nfeeds", 1)
         nant = len(data_model.uvdata.antenna_names)
         nsrc = len(data_model.sky_model.ra)
         nbeam = len(data_model.beams)

--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -12,6 +12,7 @@ from pyuvdata import utils as uvutils
 from vis_cpu import HAVE_GPU, __version__
 from vis_cpu import conversions as convs
 from vis_cpu import vis_cpu, vis_gpu
+from vis_cpu.cpu import _evaluate_beam_cpu, _wrangle_beams
 
 from .simulators import ModelData, VisibilitySimulator
 
@@ -102,7 +103,7 @@ class VisCPU(VisibilitySimulator):
             else correct_source_positions
         )
 
-        self._functions_to_profile = (self._vis_cpu,)
+        self._functions_to_profile = (self._vis_cpu, _wrangle_beams, _evaluate_beam_cpu)
 
     def validate(self, data_model: ModelData):
         """Checks for correct input format."""

--- a/scripts/hera-sim-simulate.py
+++ b/scripts/hera-sim-simulate.py
@@ -15,15 +15,15 @@ the ``config_examples`` folder in the top-level ``hera_sim`` directory.
 """
 import argparse
 import copy
+import numpy as np
 import os
 import sys
 import yaml
+from astropy import units
+from astropy.coordinates import Angle
 
-import numpy as np
 import hera_sim
 from hera_sim import cli_utils
-from astropy.coordinates import Angle
-from astropy import units
 
 try:
     import bda
@@ -68,7 +68,7 @@ if __name__ == "__main__":
     if args.verbose:
         print("Reading configuration file and validating contents...")
 
-    with open(args.config, "r") as cfg:
+    with open(args.config) as cfg:
         config = yaml.load(cfg.read(), Loader=yaml.FullLoader)
 
     cli_utils.validate_config(config)

--- a/scripts/hera-sim-vis.py
+++ b/scripts/hera-sim-vis.py
@@ -6,15 +6,15 @@ Command-line interface for simulating visibilities with ``hera_sim``.
 This script may be used to run a visibility simulation from a configuration file and
 write the result to disk.
 """
-import sys
-import yaml
 import argparse
-from pathlib import Path
-
 import numpy as np
+import pyradiosky
 import pyuvdata
 import pyuvsim
-import pyradiosky
+import sys
+import yaml
+from pathlib import Path
+
 import hera_sim
 
 try:
@@ -24,14 +24,15 @@ try:
 except ImportError:
     HAVE_MPI = False
 
+from rich.console import Console
+from rich.panel import Panel
+from rich.rule import Rule
+
 from hera_sim.visibilities import (
     ModelData,
     VisibilitySimulation,
     load_simulator_from_yaml,
 )
-from rich.console import Console
-from rich.rule import Rule
-from rich.panel import Panel
 
 cns = Console()
 

--- a/scripts/hera-sim-vis.py
+++ b/scripts/hera-sim-vis.py
@@ -111,7 +111,7 @@ if __name__ == "__main__":
         """
     )
 
-    ram = simulator.estimate_memory()
+    ram = simulator.estimate_memory(data_model)
     ram_avail = psutil.virtual_memory().available * 1024**3
 
     cprint(

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,94 +1,86 @@
-# This file is used to configure your project.
-# Read more about the various options under:
-# http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
-
 [metadata]
 name = hera_sim
 description = A collection of simulation routines describing the HERA instrument.
+long_description = file: README.rst
+long_description_content_type = text/x-rst
+url = https://github.com/HERA-Team/hera_sim
 author = HERA Team
 author_email = steven.g.murray@asu.edu
-license = BSD
-long_description = file: README.md
-long_description_content_type = text/x-rst; charset=UTF-8
-url = https://github.com/HERA-Team/hera_sim
-project_urls =
-    Documentation = https://hera_sim.readthedocs.org
-# Change if running only on Windows, Mac or Linux (comma-separated)
+license = MIT
+license_file = LICENSE.rst
 platforms = any
-# Add here all kinds of additional classifiers as defined under
-# https://pypi.python.org/pypi?%3Aaction=list_classifiers
 classifiers =
     Development Status :: 4 - Beta
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
-    Programming Language :: Python :: 3.8
     Intended Audience :: Science/Research
     License :: OSI Approved
+    License :: OSI Approved :: MIT License
     Natural Language :: English
-    Topic :: Scientific/Engineering :: Physics
+    Programming Language :: Python :: 3
+    Programming Language :: Python :: 3 :: Only
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Astronomy
+    Topic :: Scientific/Engineering :: Physics
+project_urls =
+    Documentation = https://hera_sim.readthedocs.org
 
 [options]
-zip_safe = False
 packages = find:
+install_requires =
+    astropy
+    astropy-healpix
+    cached-property
+    deprecation
+    numpy>=1.14
+    pyuvdata
+    pyuvsim>=1.1.2
+    pyyaml>=5.1
+    rich
+    scipy
+python_requires = >=3.8
 include_package_data = True
 scripts =
     scripts/hera-sim-simulate.py
     scripts/hera-sim-vis.py
-
-install_requires =
-    numpy>=1.14
-    scipy
-    cached_property
-    pyuvsim>=1.1.2
-    pyuvdata
-    astropy_healpix
-    astropy
-    deprecation
-    pyyaml>=5.1
-    rich
+zip_safe = False
 
 [options.packages.find]
 exclude =
     tests
 
 [options.extras_require]
-vis =
-    vis_cpu>=1.0.0
-    pyradiosky>=0.1.2
-    mpi4py
 bda =
     bda
+cal =
+    hera-calibration
+dev =
+    vis-cpu[docs,tests]
+docs =
+    ipython
+    nbsphinx
+    nbsphinx
+    numpydoc>=0.8
+    sphinx>=1.8
+    sphinx-autorun
+    vis-cpu[vis]
 gpu =
     pycuda
     scikit-cuda
-cal =
-    hera-calibration
-docs =
-    sphinx>=1.8
-    nbsphinx
-    ipython
-    sphinx_autorun
-    numpydoc>=0.8
-    nbsphinx
-    vis_cpu[vis]
 tests =
     coverage>=4.5.1
+    matplotlib>=3.4.2
+    pre-commit
     pytest>=3.5.1
     pytest-cov>=2.5.1
-    pre-commit
-    matplotlib>=3.4.2
     uvtools
-    vis_cpu[vis,bda,cal]
-dev =
-    vis_cpu[docs,tests]
-
+    vis-cpu[vis,bda,cal]
+vis =
+    mpi4py
+    pyradiosky>=0.1.2
+    vis-cpu>=1.0.0
 
 [tool:pytest]
-# Options for py.test:
-# Specify command line options as you would do when invoking py.test directly.
-# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
-# in order to write a coverage file that can be read by Jenkins.
 addopts =
     --cov hera_sim
     --cov-config=.coveragerc
@@ -105,7 +97,6 @@ testpaths = hera_sim/tests
 dists = bdist_wheel
 
 [bdist_wheel]
-# Use this option if your package is pure-python
 universal = 1
 
 [build_sphinx]

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,10 @@ exclude =
     tests
 
 [options.extras_require]
+vis =
+    vis_cpu>=1.0.0
+    pyradiosky>=0.1.2
+    mpi4py
 bda =
     bda
 gpu =
@@ -67,8 +71,7 @@ docs =
     sphinx_autorun
     numpydoc>=0.8
     nbsphinx
-    vis_cpu>=0.4.1
-    pyradiosky>=0.1.2
+    vis_cpu[vis]
 tests =
     coverage>=4.5.1
     pytest>=3.5.1
@@ -76,26 +79,10 @@ tests =
     pre-commit
     matplotlib>=3.4.2
     uvtools
-    hera-calibration
-    bda
-    vis_cpu>=0.4.1
+    vis_cpu[vis,bda,cal]
 dev =
-    sphinx>=1.8
-    numpydoc>=0.8.0
-    nbsphinx
-    ipython
-    coverage>=4.5.1
-    pytest>=3.5.1
-    pytest-cov>=2.5.1
-    pre-commit
-    uvtools
-    hera-calibration
-    bda
-    vis_cpu>=0.4.1
-vis =
-    vis_cpu>=0.4.1
-    pyradiosky>=0.1.2
-    mpi4py
+    vis_cpu[docs,tests]
+
 
 [tool:pytest]
 # Options for py.test:


### PR DESCRIPTION
The `use_pixel_beams` and `bm_pix` options are no longer available. `use_pixel_beam` is always effectively False. This has been deprecated already for a while.

One upshot of this is that some of the beam tests no longer work -- some of them were comparing a pixel beam sim to a non-pixel-beam sim. I don't think this was a particularly good strategy for testing the beams anyway, and I've removed the code. But we should probably come up with something to replace those kinds of tests.