### PR TITLE
fix: make uvbeam optional in MutualCoupling init

### DIFF
--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -785,7 +785,7 @@ class MutualCoupling(Crosstalk):
 
     def __init__(
         self,
-        uvbeam: UVBeam | str | Path | None,
+        uvbeam: UVBeam | str | Path | None = None,
         reflection: np.ndarray | Callable | None = None,
         omega_p: np.ndarray | Callable | None = None,
         ant_1_array: np.ndarray | None = None,

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -1120,7 +1120,7 @@ class MutualCoupling(Crosstalk):
                 # then this is where we would do it.
                 bl_len = np.linalg.norm(enu_antpos[j] - enu_antpos[i])
                 delay = np.exp(
-                    2j * np.pi * freqs * bl_len / constants.c.to("m/ns").value
+                    -2j * np.pi * freqs * bl_len / constants.c.to("m/ns").value
                 ).reshape(-1, 1, 1)
                 coupling = delay * jones_prod / bl_len
 

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -434,8 +434,8 @@ def test_mutual_coupling(use_numba):
             taper="bh",
         )
         for ak in uvdata.antenna_numbers:
-            dly_ik = delays[(ai, ak)]
-            dly_kj = -delays[(ak, aj)]  # This coupling term is conjugated.
+            dly_ik = -delays[(ai, ak)]
+            dly_kj = delays[(ak, aj)]  # This coupling term is conjugated.
             frate_ik = fringe_rates[(ai, ak)]
             frate_kj = fringe_rates[(ak, aj)]
 


### PR DESCRIPTION
It isn't necessary to provide an argument for the `uvbeam` parameter when initializing the `MutualCoupling` class, but this parameter was required prior to this update. This PR fixes that issue.