### PR TITLE
fix: pass spline_interp_opts

### DIFF
--- a/hera_sim/visibilities/vis_cpu.py
+++ b/hera_sim/visibilities/vis_cpu.py
@@ -390,6 +390,7 @@ class VisCPU(VisibilitySimulator):
                 I_sky=data_model.sky_model.stokes[0, i].to("Jy").value,
                 beam_list=beam_list,
                 beam_idx=beam_ids,
+                beam_spline_opts=data_model.beams.spline_interp_opts,
                 precision=self._precision,
                 polarized=polarized,
                 **self.kwargs,


### PR DESCRIPTION
This PR fix an issue where the `spline_interp_opts` keyword does not get passed to the `vis_cpu` wrapper, rendering linear vs cubic interpolation indifferent