### PR TITLE
Fix adjustment issues

### DIFF
--- a/hera_sim/adjustment.py
+++ b/hera_sim/adjustment.py
@@ -789,7 +789,7 @@ def rephase_to_reference(
             vis = data[antpairpol]
             bl = bls[antpairpol]
             new_data[this_slice, :, pol_ind] = lst_rephase(
-                vis, bl, data.freqs, dlst, lat=lat, array=True
+                vis, bl, data.freqs, dlst, lat=lat, inplace=False, array=True
             )
 
     # Convert from HERAData object to UVData object


### PR DESCRIPTION
This fixes the broken tests for the `adjustment.py` module. The issues were due to phasing information (apparent RA, dec, frame position angle, and field IDs) now being a required attribute of `UVData` objects. Since these are "blt-like" arrays, they also need to be updated when interpolating the data to a different LST grid.