### PR TITLE
maint: depend on pyuvdata>2.4.0 to avoid time-based bugs

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -31,7 +31,7 @@ install_requires =
     deprecation
     hera-cli-utils>=0.1.0
     numpy>=1.18
-    pyuvdata>=2.2.12
+    pyuvdata>=2.4.0
     pyuvsim>=1.2.5
     pyyaml>=5.1
     rich


### PR DESCRIPTION
Fixes #271