### PR TITLE
fix: conjugation error in matvis wrapper

### DIFF
--- a/hera_sim/visibilities/matvis.py
+++ b/hera_sim/visibilities/matvis.py
@@ -413,7 +413,7 @@ class MatVis(VisibilitySimulator):
             return visfull
 
     def _reorder_vis(self, req_pols, uvdata, visfull, vis, ant_list, polarized):
-        ant1idx, ant2idx = np.triu_indices(vis.shape[-1])
+        ant1idx, ant2idx = np.tril_indices(vis.shape[-1])
 
         try:
             if (


### PR DESCRIPTION
I don't think this is finished, but I wanted to at least get a start on it since I had kept punting on it. There are a few issues I'd still like to address, but I'm a bit too tired today to write good code, so I'll just note the things here:

* I think the default `blt_order` may have changed from `('time', 'ant1')` to something like `('time', 'baseline')`. This is functionally the same, but the different name means the big `if` clause (~line 420 in `matvis.py`) will be skipped when it shouldn't.
* I think we can also populate the visibility matrix quickly with `('time', 'ant2')` ordering by taking the upper triangular indices of the visibility matrix.
* I would like to write some tests that appeal to the simulated visibilities to ensure the conjugation convention is correct. Here are two relatively simple ideas I have:
    * Single frequency, roughly an hour or so obstime with a small array, with a single source transiting zenith. Check that the fringe-rate transform (using a FFT and *not* an iFFT) peaks at positive fringe-rates.
    * Single time, roughly ten-ish MHz with a small array, with a single source somewhere overhead. We should be able to analytically calculate the delay spectrum peak for a given antenna conjugation.