### PR TITLE
Update to new numpy RNG API

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -11,6 +11,8 @@ ignore =
     D401,
     # allow method names to be the same as python builtins
     A003,
+    # allow module names to be the same as python builtins
+    A005,
     # inline strong start-string without end-string. This is OK in the case of **kwargs in parameters.
     RST210,
     # Logging statement uses f-string.

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -5,6 +5,23 @@ Changelog
 dev
 ===
 
+Added
+-----
+- Classes subclassed from ``SimulationComponent`` now have a ``is_randomized``
+  class attribute that informs the ``Simulator`` of whether it should provide
+  a ``BitGenerator`` to the class when simulating the component.
+  - Classes which use a random component should now have a ``rng`` attribute,
+    which should be treated in the same manner as other model parameters. In
+    other words, random states are now effectively treated as model parameters.
+  
+Changed
+-------
+- All random number generation now uses the new ``numpy`` API.
+  - Rather than seed the global random state, a new ``BitGenerator`` is made
+    with whatever random seed is desired.
+  - The Simulator API has remained virtually unchanged, but the internal logic
+    that handles random state management has received a significant update.
+
 Deprecated
 ----------
 

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,7 +13,7 @@ Added
   - Classes which use a random component should now have a ``rng`` attribute,
     which should be treated in the same manner as other model parameters. In
     other words, random states are now effectively treated as model parameters.
-  
+
 Changed
 -------
 - All random number generation now uses the new ``numpy`` API.

--- a/hera_sim/components.py
+++ b/hera_sim/components.py
@@ -44,6 +44,8 @@ class SimulationComponent(metaclass=ABCMeta):
 
     #: Whether this systematic multiplies existing visibilities
     is_multiplicative: bool = False
+    #: Whether this systematic contains a randomized component
+    is_randomized: bool = False
     #: Whether the returned value is per-antenna, per-baseline, or the full array
     return_type: str | None = None
     # This isn't exactly safe, but different instances of a class should

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -61,6 +61,7 @@ class NoiselikeEoR(EoR):
         max_delay: Optional[float] = None,
         fringe_filter_type: str = "tophat",
         fringe_filter_kwargs: Optional[dict] = None,
+        rng: np.random.Generator | None = None,
     ):
         fringe_filter_kwargs = fringe_filter_kwargs or {}
 
@@ -70,6 +71,7 @@ class NoiselikeEoR(EoR):
             max_delay=max_delay,
             fringe_filter_type=fringe_filter_type,
             fringe_filter_kwargs=fringe_filter_kwargs,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, bl_vec, **kwargs):
@@ -84,12 +86,13 @@ class NoiselikeEoR(EoR):
             max_delay,
             fringe_filter_type,
             fringe_filter_kwargs,
+            rng,
         ) = self._extract_kwarg_values(**kwargs)
 
-        # make white noise in freq/time (original says in frate/freq, not sure why)
-        data = utils.gen_white_noise(size=(len(lsts), len(freqs)))
+        # Make white noise in time and frequency.
+        data = utils.gen_white_noise(size=(len(lsts), len(freqs)), rng=rng)
 
-        # scale data by EoR amplitude
+        # Scale data by EoR amplitude
         data *= eor_amp
 
         # apply delay filter; default does nothing

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -49,6 +49,7 @@ class NoiselikeEoR(EoR):
 
     _alias = ("noiselike_eor",)
     is_smooth_in_freq = False
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         bl_vec=None,

--- a/hera_sim/eor.py
+++ b/hera_sim/eor.py
@@ -90,11 +90,8 @@ class NoiselikeEoR(EoR):
             rng,
         ) = self._extract_kwarg_values(**kwargs)
 
-        # Make white noise in time and frequency.
-        data = utils.gen_white_noise(size=(len(lsts), len(freqs)), rng=rng)
-
-        # Scale data by EoR amplitude
-        data *= eor_amp
+        # Make white noise in time and frequency with the desired amplitude.
+        data = utils.gen_white_noise(size=(len(lsts), len(freqs)), rng=rng) * eor_amp
 
         # apply delay filter; default does nothing
         # TODO: find out why bl_len_ns is hardcoded as 1e10, also

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -39,6 +39,8 @@ class DiffuseForeground(Foreground):
         Keyword arguments and associated values to be passed to
         :func:`~hera_sim.utils.rough_fringe_filter`. Default is to use the
         following settings: ``fringe_filter_type : tophat``.
+    rng: np.random.Generator, optional
+        Random number generator.
 
     Notes
     -----
@@ -76,6 +78,7 @@ class DiffuseForeground(Foreground):
         omega_p=None,
         delay_filter_kwargs=None,
         fringe_filter_kwargs=None,
+        rng=None,
     ):
         if delay_filter_kwargs is None:
             delay_filter_kwargs = {
@@ -91,6 +94,7 @@ class DiffuseForeground(Foreground):
             omega_p=omega_p,
             delay_filter_kwargs=delay_filter_kwargs,
             fringe_filter_kwargs=fringe_filter_kwargs,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, bl_vec, **kwargs):
@@ -122,6 +126,7 @@ class DiffuseForeground(Foreground):
             omega_p,
             delay_filter_kwargs,
             fringe_filter_kwargs,
+            rng,
         ) = self._extract_kwarg_values(**kwargs)
 
         if Tsky_mdl is None:
@@ -147,7 +152,7 @@ class DiffuseForeground(Foreground):
         if np.isclose(np.linalg.norm(bl_vec), 0):
             return vis
 
-        vis *= utils.gen_white_noise(vis.shape)
+        vis *= utils.gen_white_noise(size=vis.shape, rng=rng)
 
         vis = utils.rough_fringe_filter(
             vis, lsts, freqs, bl_vec[0], **fringe_filter_kwargs
@@ -191,6 +196,8 @@ class PointSourceForeground(Foreground):
     reference_freq : float, optional
         Reference frequency used to make the point source flux densities
         chromatic, in units of GHz.
+    rng: np.random.Generator, optional
+        Random number generator.
     """
 
     _alias = ("pntsrc_foreground",)
@@ -208,6 +215,7 @@ class PointSourceForeground(Foreground):
         spectral_index_mean=-1,
         spectral_index_std=0.5,
         reference_freq=0.15,
+        rng=None,
     ):
         super().__init__(
             nsrcs=nsrcs,
@@ -217,6 +225,7 @@ class PointSourceForeground(Foreground):
             spectral_index_mean=spectral_index_mean,
             spectral_index_std=spectral_index_std,
             reference_freq=reference_freq,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, bl_vec, **kwargs):
@@ -259,17 +268,17 @@ class PointSourceForeground(Foreground):
             spectral_index_mean,
             spectral_index_std,
             f0,
+            rng,
         ) = self._extract_kwarg_values(**kwargs)
 
         # get baseline length (it should already be in ns)
         bl_len_ns = np.linalg.norm(bl_vec)
 
-        # randomly generate source RAs
-        ras = np.random.uniform(0, 2 * np.pi, nsrcs)
-
-        # draw spectral indices from normal distribution
-        spec_indices = np.random.normal(
-            spectral_index_mean, spectral_index_std, size=nsrcs
+        # Randomly generate source positions and spectral indices.
+        rng = rng or np.random.default_rng()
+        ras = rng.uniform(0, 2 * np.pi, nsrcs)
+        spec_indices = rng.normal(
+            loc=spectral_index_mean, scale=spectral_index_std, size=nsrcs
         )
 
         # calculate beam width, hardcoded for HERA
@@ -278,44 +287,44 @@ class PointSourceForeground(Foreground):
         # draw flux densities from a power law
         alpha = beta + 1
         flux_densities = (
-            Smax**alpha + Smin**alpha * (1 - np.random.uniform(size=nsrcs))
+            Smax**alpha + Smin**alpha * (1 - rng.uniform(size=nsrcs))
         ) ** (1 / alpha)
 
         # initialize the visibility array
         vis = np.zeros((lsts.size, freqs.size), dtype=complex)
 
-        # iterate over ra, flux, spectral indices
+        # Compute the visibility source-by-source.
         for ra, flux, index in zip(ras, flux_densities, spec_indices):
-            # find which lst index to use?
+            # Figure out when the source crosses the meridian.
             lst_ind = np.argmin(np.abs(utils.compute_ha(lsts, ra)))
 
-            # slight offset in delay? why??
-            dtau = np.random.uniform(-1, 1) * 0.1 * bl_len_ns
+            # This is effectively baking in that up to 10% of the baseline
+            # length is oriented along the North-South direction, since this
+            # is the delay measured when the source transits the meridian.
+            # (Still need to think more carefully about this, but this seems
+            # like the right explanation for this, as well as the factor of
+            # 0.9 in the calculation of w further down.)
+            dtau = rng.uniform(-1, 1) * 0.1 * bl_len_ns
 
-            # fill in the corresponding region of the visibility array
+            # Add the contribution from the source as it transits the meridian.
             vis[lst_ind, :] += flux * (freqs / f0) ** index
-
-            # now multiply in the phase
             vis[lst_ind, :] *= np.exp(2j * np.pi * freqs * dtau)
 
-        # get hour angles for lsts at 0 RA (why?)
+        # Figure out the hour angles to use for computing the beam kernel.
         has = utils.compute_ha(lsts, 0)
 
         # convolve vis with beam at each frequency
         for j, freq in enumerate(freqs):
-            # first calculate the beam, using truncated Gaussian model
+            # Treat the beam as if it's a Gaussian with a sharp horizon.
             beam = np.exp(-(has**2) / (2 * beam_width[j] ** 2))
             beam = np.where(np.abs(has) > np.pi / 2, 0, beam)
 
-            # who the hell knows what this does
+            # Compute the phase evolution as the source transits the sky.
             w = 0.9 * bl_len_ns * np.sin(has) * freq
-
             phase = np.exp(2j * np.pi * w)
 
-            # define the convolving kernel
+            # Now actually apply the mock source transit.
             kernel = beam * phase
-
-            # now actually convolve the kernel and the raw vis
             vis[:, j] = np.fft.ifft(np.fft.fft(kernel) * np.fft.fft(vis[:, j]))
 
         return vis

--- a/hera_sim/foregrounds.py
+++ b/hera_sim/foregrounds.py
@@ -67,6 +67,7 @@ class DiffuseForeground(Foreground):
 
     _alias = ("diffuse_foreground",)
     is_smooth_in_freq = True
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         bl_vec=None,
@@ -201,6 +202,7 @@ class PointSourceForeground(Foreground):
     """
 
     _alias = ("pntsrc_foreground",)
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         bl_vec=None,

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -57,6 +57,7 @@ class ThermalNoise(Noise):
     """
 
     _alias = ("thermal_noise",)
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         autovis=None,

--- a/hera_sim/noise.py
+++ b/hera_sim/noise.py
@@ -47,13 +47,13 @@ class ThermalNoise(Noise):
         Antenna numbers for the baseline that noise is being simulated for. This is
         just used to determine whether to simulate noise via the radiometer equation
         or to just add a bias from the receiver temperature.
+    rng: np.random.Generator, optional
+        Random number generator.
 
     Notes
     -----
-    At the time of writing, we're unsure of the correct prescription for
-    autocorrelations, so we only add a receiver temperature bias to baselines that
-    are interpreted as autocorrelations (i.e. where the ``bl_vec`` parameter provided
-    on calling an instance of this class is nearly zero length).
+    Considering the SNR in autocorrelations is typically very high, we only add
+    a receiver temperature bias to the autocorrelations.
     """
 
     _alias = ("thermal_noise",)
@@ -72,6 +72,7 @@ class ThermalNoise(Noise):
         Trx=0,
         autovis=None,
         antpair=None,
+        rng=None,
     ):
         super().__init__(
             Tsky_mdl=Tsky_mdl,
@@ -81,6 +82,7 @@ class ThermalNoise(Noise):
             Trx=Trx,
             autovis=autovis,
             antpair=antpair,
+            rng=rng,
         )
 
     def __call__(self, lsts: np.ndarray, freqs: np.ndarray, **kwargs):
@@ -119,6 +121,7 @@ class ThermalNoise(Noise):
             Trx,
             autovis,
             antpair,
+            rng,
         ) = self._extract_kwarg_values(**kwargs)
 
         # get the channel width in Hz if not specified
@@ -172,7 +175,7 @@ class ThermalNoise(Noise):
         vis /= utils.jansky_to_kelvin(freqs, omega_p).reshape(1, -1)
 
         # make it noisy
-        return utils.gen_white_noise(size=vis.shape) * vis
+        return utils.gen_white_noise(size=vis.shape, rng=rng) * vis
 
     @staticmethod
     def resample_Tsky(lsts, freqs, Tsky_mdl=None, Tsky=180.0, mfreq=0.18, index=-2.5):

--- a/hera_sim/rfi.py
+++ b/hera_sim/rfi.py
@@ -136,6 +136,7 @@ class Stations(RFI):
     """
 
     _alias = ("rfi_stations",)
+    is_randomized = True
     return_type = "per_baseline"
 
     def __init__(self, stations=None, rng=None):
@@ -213,6 +214,7 @@ class Impulse(RFI):
     """
 
     _alias = ("rfi_impulse",)
+    is_randomized = True
     return_type = "per_baseline"
 
     def __init__(self, impulse_chance=0.001, impulse_strength=20.0, rng=None):
@@ -282,6 +284,7 @@ class Scatter(RFI):
     """
 
     _alias = ("rfi_scatter",)
+    is_randomized = True
     return_type = "per_baseline"
 
     def __init__(
@@ -355,6 +358,7 @@ class DTV(RFI):
     """
 
     _alias = ("rfi_dtv",)
+    is_randomized = True
     return_type = "per_baseline"
 
     def __init__(

--- a/hera_sim/rfi.py
+++ b/hera_sim/rfi.py
@@ -100,14 +100,14 @@ class RfiStation:
         ch2 = ch1 + 1 if self.f0 > freqs[ch1] else ch1 - 1
 
         # generate some random phases
-        phs1, phs2 = rng.uniform(0, 2 * np.pi, size=2)
+        phs1, phs2 = self.rng.uniform(0, 2 * np.pi, size=2)
 
         # find out when the station is broadcasting
         is_on = 0.999 * np.cos(lsts * u.sday.to("s") / self.timescale + phs1)
         is_on = is_on > (1 - 2 * self.duty_cycle)
 
         # generate a signal and filter it according to when it's on
-        signal = rng.normal(self.strength, self.std, lsts.size)
+        signal = self.rng.normal(self.strength, self.std, lsts.size)
         signal = np.where(is_on, signal, 0) * np.exp(1j * phs2)
 
         # now add the signal to the rfi array

--- a/hera_sim/rfi.py
+++ b/hera_sim/rfi.py
@@ -36,6 +36,8 @@ class RfiStation:
         are considered "off" and high points are considered "on" (just how high is
         controlled by ``duty_cycle``). This is the wavelength (in seconds) of that
         cycle.
+    rng: np.random.Generator, optional
+        Random number generator.
 
     Notes
     -----
@@ -53,12 +55,14 @@ class RfiStation:
         strength: float = 100.0,
         std: float = 10.0,
         timescale: float = 100.0,
+        rng: np.random.Generator | None = None,
     ):
         self.f0 = f0
         self.duty_cycle = duty_cycle
         self.strength = strength
         self.std = std
         self.timescale = timescale
+        self.rng = rng or np.random.default_rng()
 
     def __call__(self, lsts, freqs):
         """Compute the RFI for this station.
@@ -96,14 +100,14 @@ class RfiStation:
         ch2 = ch1 + 1 if self.f0 > freqs[ch1] else ch1 - 1
 
         # generate some random phases
-        phs1, phs2 = np.random.uniform(0, 2 * np.pi, size=2)
+        phs1, phs2 = rng.uniform(0, 2 * np.pi, size=2)
 
         # find out when the station is broadcasting
         is_on = 0.999 * np.cos(lsts * u.sday.to("s") / self.timescale + phs1)
         is_on = is_on > (1 - 2 * self.duty_cycle)
 
         # generate a signal and filter it according to when it's on
-        signal = np.random.normal(self.strength, self.std, lsts.size)
+        signal = rng.normal(self.strength, self.std, lsts.size)
         signal = np.where(is_on, signal, 0) * np.exp(1j * phs2)
 
         # now add the signal to the rfi array
@@ -127,13 +131,15 @@ class Stations(RFI):
     ----------
     stations : list of :class:`RfiStation`
         The list of stations that produce RFI.
+    rng: np.random.Generator, optional
+        Random number generator.
     """
 
     _alias = ("rfi_stations",)
     return_type = "per_baseline"
 
-    def __init__(self, stations=None):
-        super().__init__(stations=stations)
+    def __init__(self, stations=None, rng=None):
+        super().__init__(stations=stations, rng=rng)
 
     def __call__(self, lsts, freqs, **kwargs):
         """Generate the RFI from all stations.
@@ -159,7 +165,7 @@ class Stations(RFI):
         self._check_kwargs(**kwargs)
 
         # but this is where the magic comes in (thanks to defaults)
-        (stations,) = self._extract_kwarg_values(**kwargs)
+        (stations, rng) = self._extract_kwarg_values(**kwargs)
 
         # initialize an array to store the rfi in
         rfi = np.zeros((lsts.size, freqs.size), dtype=complex)
@@ -202,14 +208,18 @@ class Impulse(RFI):
         Strength of the impulse. This will not be randomized, though a phase
         offset as a function of frequency will be applied, and will be random
         for each impulse.
+    rng: np.random.Generator, optional
+        Random number generator.
     """
 
     _alias = ("rfi_impulse",)
     return_type = "per_baseline"
 
-    def __init__(self, impulse_chance=0.001, impulse_strength=20.0):
+    def __init__(self, impulse_chance=0.001, impulse_strength=20.0, rng=None):
         super().__init__(
-            impulse_chance=impulse_chance, impulse_strength=impulse_strength
+            impulse_chance=impulse_chance,
+            impulse_strength=impulse_strength,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, **kwargs):
@@ -231,18 +241,19 @@ class Impulse(RFI):
         self._check_kwargs(**kwargs)
 
         # unpack the kwargs
-        chance, strength = self._extract_kwarg_values(**kwargs)
+        chance, strength, rng = self._extract_kwarg_values(**kwargs)
+        rng = rng or np.random.default_rng()
 
         # initialize the rfi array
         rfi = np.zeros((lsts.size, freqs.size), dtype=complex)
 
         # find times when an impulse occurs
-        impulses = np.where(np.random.uniform(size=lsts.size) <= chance)[0]
+        impulses = np.where(rng.uniform(size=lsts.size) <= chance)[0]
 
         # only do something if there are impulses
         if impulses.size > 0:
             # randomly generate some delays for each impulse
-            dlys = np.random.uniform(-300, 300, impulses.size)  # ns
+            dlys = rng.uniform(-300, 300, impulses.size)  # ns
 
             # generate the signals
             signals = strength * np.asarray(
@@ -266,16 +277,21 @@ class Scatter(RFI):
         random strength).
     scatter_std : float, optional
         Standard deviation of the RFI strength.
+    rng: np.random.Generator, optional
+        Random number generator.
     """
 
     _alias = ("rfi_scatter",)
     return_type = "per_baseline"
 
-    def __init__(self, scatter_chance=0.0001, scatter_strength=10.0, scatter_std=10.0):
+    def __init__(
+        self, scatter_chance=0.0001, scatter_strength=10.0, scatter_std=10.0, rng=None
+    ):
         super().__init__(
             scatter_chance=scatter_chance,
             scatter_strength=scatter_strength,
             scatter_std=scatter_std,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, **kwargs):
@@ -297,17 +313,18 @@ class Scatter(RFI):
         self._check_kwargs(**kwargs)
 
         # now unpack them
-        chance, strength, std = self._extract_kwarg_values(**kwargs)
+        chance, strength, std, rng = self._extract_kwarg_values(**kwargs)
+        rng = rng or np.random.default_rng()
 
         # make an empty rfi array
         rfi = np.zeros((lsts.size, freqs.size), dtype=complex)
 
         # find out where to put the rfi
-        rfis = np.where(np.random.uniform(size=rfi.size) <= chance)[0]
+        rfis = np.where(rng.uniform(size=rfi.size) <= chance)[0]
 
         # simulate the rfi; one random amplitude, all random phases
-        signal = np.random.normal(strength, std) * np.exp(
-            2j * np.pi * np.random.uniform(size=rfis.size)
+        signal = rng.normal(strength, std) * np.exp(
+            2j * np.pi * rng.uniform(size=rfis.size)
         )
 
         # add the signal to the rfi
@@ -333,6 +350,8 @@ class DTV(RFI):
         Mean strength of RFI.
     dtv_std : float, optional
         Standard deviation of RFI strength.
+    rng: np.random.Generator, optional
+        Random number generator.
     """
 
     _alias = ("rfi_dtv",)
@@ -345,6 +364,7 @@ class DTV(RFI):
         dtv_chance=0.0001,
         dtv_strength=10.0,
         dtv_std=10.0,
+        rng=None,
     ):
         super().__init__(
             dtv_band=dtv_band,
@@ -352,6 +372,7 @@ class DTV(RFI):
             dtv_chance=dtv_chance,
             dtv_strength=dtv_strength,
             dtv_std=dtv_std,
+            rng=rng,
         )
 
     def __call__(self, lsts, freqs, **kwargs):
@@ -379,7 +400,9 @@ class DTV(RFI):
             dtv_chance,
             dtv_strength,
             dtv_std,
+            rng,
         ) = self._extract_kwarg_values(**kwargs)
+        rng = rng or np.random.default_rng()
 
         # make an empty rfi array
         rfi = np.zeros((lsts.size, freqs.size), dtype=complex)
@@ -449,12 +472,12 @@ class DTV(RFI):
             this_rfi = rfi[:, ch1:ch2]
 
             # find out which times are affected
-            rfis = np.random.uniform(size=lsts.size) <= chance
+            rfis = rng.uniform(size=lsts.size) <= chance
 
             # calculate the signal
             signal = np.atleast_2d(
-                np.random.normal(strength, std, size=rfis.sum())
-                * np.exp(2j * np.pi * np.random.uniform(size=rfis.sum()))
+                rng.normal(strength, std, size=rfis.sum())
+                * np.exp(2j * np.pi * rng.uniform(size=rfis.sum()))
             ).T
 
             # add the signal to the rfi array

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -381,6 +381,7 @@ class Reflections(Gain):
         """
 
         rng = rng or np.random.default_rng()
+
         def broadcast_param(param, lower_bound, upper_bound, size):
             if param is None:
                 return rng.uniform(lower_bound, upper_bound, size)

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -251,6 +251,7 @@ class Reflections(Gain):
         amp, dly, phs, conj, amp_jitter, dly_jitter, rng = self._extract_kwarg_values(
             **kwargs
         )
+        rng = rng or np.random.default_rng()
 
         # fill in missing kwargs
         amp, dly, phs = self._complete_params(
@@ -377,6 +378,7 @@ class Reflections(Gain):
             Phase of each reflection coefficient for each antenna.
         """
 
+        rng = rng or np.random.default_rng()
         def broadcast_param(param, lower_bound, upper_bound, size):
             if param is None:
                 return rng.uniform(lower_bound, upper_bound, size)

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -63,6 +63,7 @@ class Bandpass(Gain):
 
     _alias = ("gains", "bandpass_gain")
     is_multiplicative = True
+    is_randomized = True
     return_type = "per_antenna"
     attrs_to_pull = dict(
         ants="antpos",
@@ -203,6 +204,7 @@ class Reflections(Gain):
 
     _alias = ("reflection_gains", "sigchain_reflections")
     is_multiplicative = True
+    is_randomized = True
     return_type = "per_antenna"
     attrs_to_pull = dict(
         ants="antpos",
@@ -437,6 +439,7 @@ class ReflectionSpectrum(Gain):
 
     _alias = ("reflection_spectrum",)
     is_multiplicative = True
+    is_randomized = True
     return_type = "per_antenna"
     attrs_to_pull = dict(
         ants="antpos",
@@ -548,6 +551,7 @@ class CrossCouplingCrosstalk(Crosstalk, Reflections):
 
     _alias = ("cross_coupling_xtalk",)
     is_multiplicative = False
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         autovis=None,
@@ -654,6 +658,7 @@ class CrossCouplingSpectrum(Crosstalk):
     """
 
     _alias = ("cross_coupling_spectrum", "xtalk_spectrum")
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         autovis=None,
@@ -872,8 +877,6 @@ class MutualCoupling(Crosstalk):
     use_numba
         Whether to use ``numba`` for accelerating the simulation. Default is
         to use ``numba`` if it is installed.
-    rng
-        Random number generator.
     """
 
     _alias = ("mutual_coupling", "first_order_coupling")
@@ -900,7 +903,6 @@ class MutualCoupling(Crosstalk):
         freq_interp: str = "cubic",
         beam_kwargs: dict | None = None,
         use_numba: bool = True,
-        rng: np.random.Generator | None = None,
     ):
         super().__init__(
             uvbeam=uvbeam,
@@ -915,7 +917,6 @@ class MutualCoupling(Crosstalk):
             freq_interp=freq_interp,
             beam_kwargs=beam_kwargs or {},
             use_numba=use_numba,
-            rng=rng,
         )
 
     def __call__(
@@ -964,7 +965,6 @@ class MutualCoupling(Crosstalk):
             freq_interp,
             beam_kwargs,
             use_numba,
-            rng,
         ) = self._extract_kwarg_values(**kwargs)
 
         # Do all our sanity checks up front. First, check the array.
@@ -1341,6 +1341,7 @@ class OverAirCrossCoupling(Crosstalk):
     :class:`CrossCouplingSpectrum`
     """
 
+    is_randomized = True
     return_type = "per_baseline"
     attrs_to_pull = dict(
         antpair=None,
@@ -1485,6 +1486,7 @@ class WhiteNoiseCrosstalk(Crosstalk):
         "whitenoise_xtalk",
         "white_noise_xtalk",
     )
+    is_randomized = True
     return_type = "per_baseline"
 
     def __init__(self, amplitude=3.0, rng=None):

--- a/hera_sim/sigchain.py
+++ b/hera_sim/sigchain.py
@@ -15,7 +15,6 @@ from collections.abc import Sequence
 from pathlib import Path
 from pyuvdata import UVBeam
 from pyuvsim import AnalyticBeam
-from scipy import stats
 from scipy.signal.windows import blackmanharris
 from typing import Callable
 
@@ -560,7 +559,7 @@ class CrossCouplingCrosstalk(Crosstalk, Reflections):
         conj=False,
         amp_jitter=0,
         dly_jitter=0,
-        rng=rng,
+        rng=None,
     ):
         super().__init__(
             amp=amp,

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -1121,7 +1121,8 @@ class Simulator:
                 # Prepare the actual arguments to be used.
                 use_args = self._update_args(base_args, model, ant1, ant2, pol)
                 use_args.update(kwargs)
-                use_args["rng"] = rng
+                if model.is_randomized:
+                    use_args["rng"] = rng
                 if use_cached_filters:
                     filter_kwargs = self._get_filters(
                         ant1,

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -10,7 +10,6 @@ import contextlib
 import functools
 import inspect
 import numpy as np
-import time
 import warnings
 import yaml
 from astropy import constants as const
@@ -964,7 +963,7 @@ class Simulator:
         *,
         add_vis: bool = True,
         ret_vis: bool = False,
-        seed: str | int | None = None
+        seed: str | int | None = None,
         vis_filter: Sequence | None = None,
         antpairpol_cache: Sequence[AntPairPol] | None = None,
         model_key: str | None = None,
@@ -1194,9 +1193,7 @@ class Simulator:
         uvd.read(datafile, read_data=True, **kwargs)
         return uvd
 
-    def _seed_rng(
-        self, seed, model, ant1=None, ant2=None, pol=None, model_key=None
-    ):
+    def _seed_rng(self, seed, model, ant1=None, ant2=None, pol=None, model_key=None):
         """
         Set the random state according to the provided parameters.
 
@@ -1266,9 +1263,7 @@ class Simulator:
         """
         model_key = model_key or self._get_model_name(model)
         if seed is None:
-            rng = getattr(
-                self._components[model_key]["rng"], np.random.default_rng()
-            )
+            rng = getattr(self._components[model_key]["rng"], np.random.default_rng())
             return (None, rng)
         if isinstance(seed, int):
             return (seed, np.random.default_rng(seed))

--- a/hera_sim/simulate.py
+++ b/hera_sim/simulate.py
@@ -300,8 +300,6 @@ class Simulator:
             for param in getattr(model, "kwargs", {}):
                 if param not in kwargs and param in defaults():
                     kwargs[param] = defaults(param)
-        if vis_filter is not None:
-            kwargs["vis_filter"] = vis_filter
         self._components[model_key] = kwargs.copy()
         self._components[model_key]["alias"] = component
 
@@ -320,8 +318,10 @@ class Simulator:
         if add_vis:
             self._update_history(model, **kwargs)
             if seed:
-                kwargs["seed"] = seed
+                self._components[model_key]["seed"] = seed
                 self._update_seeds(model_key)
+            if vis_filter is not None:
+                kwargs["vis_filter"] = vis_filter
         else:
             del self._antpairpol_cache[model_key]
             del self._components[model_key]
@@ -481,9 +481,13 @@ class Simulator:
             args = self._update_args(args, model, ant1, ant2, pol)
             args.update(kwargs)
             if conj_data:
-                _, rng = self._seed_rng(seed, model, ant2, ant1, _pol)
+                _, rng = self._seed_rng(
+                    seed, model, ant2, ant1, _pol, model_key=model_key
+                )
             else:
-                _, rng = self._seed_rng(seed, model, ant1, ant2, _pol)
+                _, rng = self._seed_rng(
+                    seed, model, ant1, ant2, _pol, model_key=model_key
+                )
             args["rng"] = rng
             data[..., i] = model(**args)
         if conj_data:

--- a/hera_sim/tests/test_adjustment.py
+++ b/hera_sim/tests/test_adjustment.py
@@ -131,7 +131,8 @@ def test_match_subarray():
 
 def test_match_translated_array():
     # A simple translation should just be undone
-    translation = np.random.uniform(-1, 1, 3)
+    rng = np.random.default_rng(0)
+    translation = rng.uniform(-1, 1, 3)
     array_1 = {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0]}
     array_2 = {ant: np.array(pos) - translation for ant, pos in array_1.items()}
     # Won't be an exact match to machine precision, so need some small tolerance.

--- a/hera_sim/tests/test_adjustment.py
+++ b/hera_sim/tests/test_adjustment.py
@@ -10,7 +10,6 @@ import os
 from astropy import units
 from pyuvdata import UVData
 from pyuvdata.utils import antnums_to_baseline
-from scipy import stats
 
 from hera_sim import Simulator, adjustment, antpos, interpolators
 
@@ -264,8 +263,9 @@ def test_match_antennas_using_reference_positions_and_labels(base_sim, base_conf
     jitter_radius = 0.1  # 10 cm
     new_array = {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [2, 1, 0], 4: [2, 2, 0]}
     base_config["array_layout"] = scale_array(new_array)
+    rng = np.random.default_rng(0)
     new_array = {
-        ant: pos + stats.uniform.rvs(-jitter_radius, jitter_radius, 3)
+        ant: pos + rng.uniform(-jitter_radius, jitter_radius, 3)
         for ant, pos in base_config["array_layout"].items()
     }  # Mess up the antenna positions by up to 10 cm in each direction, randomly.
     base_config["array_layout"] = new_array
@@ -297,8 +297,9 @@ def test_match_antennas_use_reference_positions_only(base_sim, base_config):
     jitter_radius = 0.1  # 10 cm
     new_array = {0: [0, 0, 0], 1: [1, 0, 0], 2: [1, 1, 0], 3: [2, 1, 0], 4: [2, 2, 0]}
     base_config["array_layout"] = scale_array(new_array)
+    rng = np.random.default_rng(0)
     new_array = {
-        ant: pos + stats.uniform.rvs(-jitter_radius, jitter_radius, 3)
+        ant: pos + rng.uniform(-jitter_radius, jitter_radius, 3)
         for ant, pos in base_config["array_layout"].items()
     }  # Mess up the antenna positions by up to 10 cm in each direction, randomly.
     base_config["array_layout"] = new_array

--- a/hera_sim/tests/test_compare_pyuvsim.py
+++ b/hera_sim/tests/test_compare_pyuvsim.py
@@ -66,10 +66,11 @@ def get_sky_model(uvdata, nsource):
     sources = [
         [125.7, -30.72, 2, 0],  # Fix a single source near zenith
     ]
+    rng = np.random.default_rng(0)
     if nsource > 1:  # Add random other sources
-        ra = np.random.uniform(low=0.0, high=360.0, size=nsource - 1)
-        dec = -30.72 + np.random.random(nsource - 1) * 10.0
-        flux = np.random.random(nsource - 1) * 4
+        ra = rng.uniform(low=0.0, high=360.0, size=nsource - 1)
+        dec = -30.72 + rng.random(nsource - 1) * 10.0
+        flux = rng.random(nsource - 1) * 4
         for i in range(nsource - 1):
             sources.append([ra[i], dec[i], flux[i], 0])
     sources = np.array(sources)

--- a/hera_sim/tests/test_compare_pyuvsim.py
+++ b/hera_sim/tests/test_compare_pyuvsim.py
@@ -28,12 +28,12 @@ def get_uvdata(pol_array=None):
     obstime = Time("2018-08-31T04:02:30.11", format="isot", scale="utc")
     if pol_array is None:
         pol_array = np.array(["XX", "YY", "XY", "YX"])
-    np.random.seed(10)
+    rng = np.random.default_rng(10)
 
     # Random antenna locations
-    x = np.random.random(nants) * 400.0  # Up to 400 metres
-    y = np.random.random(nants) * 400.0
-    z = np.random.random(nants) * 0.0
+    x = rng.random(nants) * 400.0  # Up to 400 metres
+    y = rng.random(nants) * 400.0
+    z = rng.random(nants) * 0.0
 
     ants = {i: (x[i], y[i], z[i]) for i in range(nants)}
 

--- a/hera_sim/tests/test_defaults.py
+++ b/hera_sim/tests/test_defaults.py
@@ -44,11 +44,9 @@ def test_multiple_param_specification():
 def test_bandpass_changes():
     defaults.set("h1c", refresh=True)
     fqs = np.linspace(0.1, 0.2, 100)
-    np.random.seed(0)
-    bp = gen_bandpass(fqs, [0])[0]
+    bp = gen_bandpass(fqs, [0], rng=np.random.default_rng(0))[0]
     defaults.set("h2c", refresh=True)
-    np.random.seed(0)
-    assert not np.all(bp == gen_bandpass(fqs, [0])[0])
+    assert not np.all(bp == gen_bandpass(fqs, [0], rng=np.random.default_rng(0))[0])
     defaults.deactivate()
 
 

--- a/hera_sim/tests/test_eor.py
+++ b/hera_sim/tests/test_eor.py
@@ -22,21 +22,29 @@ def bl_vec():
 
 @pytest.fixture(scope="function")
 def base_eor(freqs, lsts, bl_vec, request):
-    np.random.seed(0)
     if request.param == "auto":
         bl_vec = np.array([0, 0, 0])
     return eor.noiselike_eor(
-        lsts=lsts, freqs=freqs, bl_vec=bl_vec, eor_amp=1e-5, fringe_filter_type="tophat"
+        lsts=lsts,
+        freqs=freqs,
+        bl_vec=bl_vec,
+        eor_amp=1e-5,
+        fringe_filter_type="tophat",
+        rng=np.random.default_rng(0),
     )
 
 
 @pytest.fixture(scope="function")
 def scaled_eor(freqs, lsts, bl_vec, request):
-    np.random.seed(0)
     if request.param == "auto":
         bl_vec = np.array([0, 0, 0])
     return eor.noiselike_eor(
-        lsts=lsts, freqs=freqs, bl_vec=bl_vec, eor_amp=1e-3, fringe_filter_type="tophat"
+        lsts=lsts,
+        freqs=freqs,
+        bl_vec=bl_vec,
+        eor_amp=1e-3,
+        fringe_filter_type="tophat",
+        rng=np.random.default_rng(0),
     )
 
 

--- a/hera_sim/tests/test_foregrounds.py
+++ b/hera_sim/tests/test_foregrounds.py
@@ -123,8 +123,8 @@ def test_foreground_conjugation(freqs, lsts, Tsky_mdl, omega_p, model):
 
     conj_kwargs = kwargs.copy()
     conj_kwargs["bl_vec"] = -bl_vec
-    vis = model(**kwargs)
-    conj_vis = model(**conj_kwargs)
+    vis = model(**kwargs, rng=np.random.default_rng(0))
+    conj_vis = model(**conj_kwargs, rng=np.random.default_rng(0))
     assert np.allclose(vis, conj_vis.conj())  # Assert V_ij = V*_ji
 
 

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -81,7 +81,6 @@ def test_resample_Tsky_freq_behavior(tsky_powerlaw, tsky_from_model, model):
 def test_sky_noise_jy(
     freqs, lsts, tsky_powerlaw, Jy2T, omega_p, channel_width, integration_time, aspect
 ):
-    np.random.seed(0)
     noise_Jy = noise.sky_noise_jy(
         lsts=lsts,
         freqs=freqs,
@@ -89,6 +88,7 @@ def test_sky_noise_jy(
         omega_p=omega_p,
         channel_width=channel_width,
         integration_time=integration_time,
+        rng=np.random.default_rng(0),
     )
 
     # Calculate expected noise level based on radiometer equation.

--- a/hera_sim/tests/test_noise.py
+++ b/hera_sim/tests/test_noise.py
@@ -122,6 +122,7 @@ def test_thermal_noise_with_phase_wrap(freqs, omega_p, autovis, expectation):
     channel_width = np.mean(np.diff(freqs)) * units.GHz.to("Hz")
     expected_SNR = np.sqrt(integration_time * channel_width)
     Trx = 0
+    rng = np.random.default_rng(0)
     if autovis is not None:
         autovis = np.ones((wrapped_lsts.size, freqs.size), dtype=complex)
     noise_sim = noise.ThermalNoise(
@@ -129,6 +130,7 @@ def test_thermal_noise_with_phase_wrap(freqs, omega_p, autovis, expectation):
         omega_p=omega_p,
         Trx=Trx,
         autovis=autovis,
+        rng=rng,
     )
     with expectation:
         vis = noise_sim(lsts=wrapped_lsts, freqs=freqs)

--- a/hera_sim/tests/test_rfi.py
+++ b/hera_sim/tests/test_rfi.py
@@ -55,8 +55,7 @@ def test_rfi_station_from_file(freqs, lsts):
 @pytest.mark.parametrize("rfi_type", ["scatter", "impulse", "dtv"])
 @pytest.mark.parametrize("chance", [0.2, 0.5, 0.8])
 def test_rfi_occupancy(freqs, lsts, rfi_type, chance):
-    np.random.seed(0)
-    kwargs = {f"{rfi_type}_chance": chance}
+    kwargs = {f"{rfi_type}_chance": chance, "rng": np.random.default_rng(0)}
     # Modify expected chance appropriately if simulating DTV.
     if rfi_type == "dtv":
         fmin, fmax = (0.15, 0.20)
@@ -64,12 +63,11 @@ def test_rfi_occupancy(freqs, lsts, rfi_type, chance):
         freq_cut = (freqs >= fmin) & (freqs < fmax)
         chance *= freqs[freq_cut].size / freqs.size
     rfi_vis = getattr(rfi, f"rfi_{rfi_type}")(lsts, freqs, **kwargs)
-    assert np.isclose(np.mean(np.abs(rfi_vis).astype(bool)), chance, atol=0.05, rtol=0)
+    assert np.isclose(np.mean(np.abs(rfi_vis).astype(bool)), chance, atol=0.1, rtol=0)
 
 
 @pytest.mark.parametrize("alignment", ["aligned", "misaligned"])
 def test_rfi_dtv_constant_across_subband(freqs, lsts, alignment):
-    np.random.seed(0)
     dtv_band = (0.15, 0.20) if alignment == "aligned" else (0.1502, 0.2002)
     channel_width = 0.01
     Nbands = 5  # Just hardcode this to avoid stupid numerical problems.
@@ -82,6 +80,7 @@ def test_rfi_dtv_constant_across_subband(freqs, lsts, alignment):
         dtv_chance=0.5,
         dtv_strength=10,
         dtv_std=1,
+        rng=np.random.default_rng(0),
     )
     for band_edges in zip(subband_edges[:-1], subband_edges[1:]):
         channels = np.argwhere(
@@ -97,7 +96,6 @@ def test_rfi_dtv_constant_across_subband(freqs, lsts, alignment):
 
 
 def test_rfi_dtv_occupancy_variable_chance(freqs, lsts):
-    np.random.seed(0)
     dtv_band = (0.15, 0.20)
     channel_width = 0.01
     Nbands = 5  # See above note about hardcoding.
@@ -111,6 +109,7 @@ def test_rfi_dtv_occupancy_variable_chance(freqs, lsts):
         dtv_chance=chances,
         dtv_strength=10,
         dtv_std=1,
+        rng=np.random.default_rng(0),
     )
     expected_occupancy = sum(
         chance

--- a/hera_sim/tests/test_rfi.py
+++ b/hera_sim/tests/test_rfi.py
@@ -18,7 +18,7 @@ def lsts():
 @pytest.mark.parametrize("station_freq", [0.150, 0.1505])
 def test_rfi_station_strength(freqs, lsts, station_freq):
     # Generate RFI for a single station.
-    station = rfi.RfiStation(station_freq, std=0.0)
+    station = rfi.RfiStation(station_freq, std=0.0, rng=np.random.default_rng(0))
     rfi_vis = station(lsts, freqs)
 
     # Check that the RFI is inserted where it should be at the correct level.
@@ -48,7 +48,9 @@ def test_rfi_station_from_file(freqs, lsts):
     filename = DATA_PATH / "HERA_H1C_RFI_STATIONS.npy"
     station_params = np.load(filename)
     Nstations = station_params.shape[0]
-    rfi_vis = rfi.rfi_stations(lsts, freqs, stations=filename)
+    rfi_vis = rfi.rfi_stations(
+        lsts, freqs, stations=filename, rng=np.random.default_rng(0)
+    )
     assert np.sum(np.sum(np.abs(rfi_vis), axis=0).astype(bool)) >= Nstations
 
 

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -143,7 +143,10 @@ def test_reflection_gains_correct_delays(
     dlys,
 ):
     # introduce a cable reflection into the autocorrelation
-    gains = sigchain.gen_reflection_gains(fqs, [0], amp=[1e-1], dly=[300], phs=[1])
+    rng = np.random.default_rng(0)
+    gains = sigchain.gen_reflection_gains(
+        fqs, [0], amp=[1e-1], dly=[300], phs=[1], rng=rng
+    )
     outvis = sigchain.apply_gains(vis, gains, [0, 0])
     ovfft = uvtools.utils.FFT(outvis, axis=1, taper="blackman-harris")
 

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -588,9 +588,10 @@ def test_mutual_coupling_input_types(
     def func(freqs):
         return np.ones_like(freqs)
 
+    rng = np.random.default_rng(0)
     omega_p = func if omega_p == "callable" else None
     reflection = func if reflection == "callable" else None
-    data = np.random.normal(size=sample_uvdata.data_array.shape) + 0j
+    data = rng.normal(size=sample_uvdata.data_array.shape) + 0j
     sample_uvdata.data_array += data
     sample_uvdata.data_array += sample_coupling(
         freqs=sample_uvdata.freq_array.squeeze() / 1e9,

--- a/hera_sim/tests/test_sigchain.py
+++ b/hera_sim/tests/test_sigchain.py
@@ -11,8 +11,6 @@ from hera_sim import DATA_PATH, foregrounds, noise, sigchain
 from hera_sim.interpolators import Bandpass, Beam
 from hera_sim.io import empty_uvdata
 
-np.random.seed(0)
-
 
 @pytest.fixture(scope="function")
 def fqs():
@@ -570,8 +568,8 @@ def uvbeam(tmp_path):
 
 
 def test_mutual_coupling_with_uvbeam(uvbeam, sample_uvdata, sample_coupling):
-    np.random.seed(0)
-    data = np.random.normal(size=sample_uvdata.data_array.shape) + 0j
+    rng = np.random.default_rng(0)
+    data = rng.normal(size=sample_uvdata.data_array.shape) + 0j
     sample_uvdata.data_array[...] = data[...]
     sample_uvdata.data_array += sample_coupling(
         freqs=sample_uvdata.freq_array.squeeze() / 1e9,

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -112,17 +112,27 @@ def test_nondefault_blt_order_lsts():
 
 
 def test_add_with_str(base_sim):
-    base_sim.add("noiselike_eor")
+    base_sim.add("noiselike_eor", rng=np.random.default_rng(0))
     assert not np.all(base_sim.data.data_array == 0)
 
 
 def test_add_with_builtin_class(base_sim):
-    base_sim.add(DiffuseForeground, Tsky_mdl=Tsky_mdl, omega_p=omega_p)
+    base_sim.add(
+        DiffuseForeground,
+        Tsky_mdl=Tsky_mdl,
+        omega_p=omega_p,
+        rng=np.random.default_rng(0),
+    )
     assert not np.all(np.isclose(base_sim.data.data_array, 0))
 
 
 def test_add_with_class_instance(base_sim):
-    base_sim.add(diffuse_foreground, Tsky_mdl=Tsky_mdl, omega_p=omega_p)
+    base_sim.add(
+        diffuse_foreground,
+        Tsky_mdl=Tsky_mdl,
+        omega_p=omega_p,
+        rng=np.random.default_rng(0),
+    )
     assert not np.all(np.isclose(base_sim.data.data_array, 0))
 
 
@@ -301,7 +311,9 @@ def test_get_multiplicative_effect(base_sim, pol, ant1):
 
 
 def test_not_add_vis(base_sim):
-    vis = base_sim.add("noiselike_eor", add_vis=False, ret_vis=True)
+    vis = base_sim.add(
+        "noiselike_eor", add_vis=False, ret_vis=True, rng=np.random.default_rng(0)
+    )
 
     assert np.all(base_sim.data.data_array == 0)
 
@@ -315,14 +327,16 @@ def test_not_add_vis(base_sim):
 
 
 def test_adding_vis_but_also_returning(base_sim):
-    vis = base_sim.add("noiselike_eor", ret_vis=True)
+    vis = base_sim.add("noiselike_eor", ret_vis=True, rng=np.random.default_rng(0))
 
     assert not np.all(vis == 0)
     assert np.all(np.isclose(vis, base_sim.data.data_array))
 
     # use season defaults for simplicity
     defaults.set("h1c")
-    vis += base_sim.add("diffuse_foreground", ret_vis=True)
+    vis += base_sim.add(
+        "diffuse_foreground", ret_vis=True, rng=np.random.default_rng(90)
+    )
     # deactivate defaults for good measure
     defaults.deactivate()
     assert np.all(np.isclose(vis, base_sim.data.data_array))
@@ -334,7 +348,7 @@ def test_filter():
     # only add visibilities for the (0,1) baseline
     vis_filter = (0, 1, "xx")
 
-    sim.add("noiselike_eor", vis_filter=vis_filter)
+    sim.add("noiselike_eor", vis_filter=vis_filter, rng=np.random.default_rng(10))
     assert np.all(sim.data.get_data(0, 0) == 0)
     assert np.all(sim.data.get_data(1, 1) == 0)
     assert np.all(sim.data.get_data(0, 1) != 0)
@@ -599,13 +613,13 @@ def test_legacy_funcs(component):
 
 def test_vis_filter_single_pol():
     sim = create_sim(polarization_array=["xx", "yy"])
-    sim.add("noiselike_eor", vis_filter=["xx"])
+    sim.add("noiselike_eor", vis_filter=["xx"], rng=np.random.default_rng(99))
     assert np.all(sim.get_data("xx")) and not np.any(sim.get_data("yy"))
 
 
 def test_vis_filter_two_pol():
     sim = create_sim(polarization_array=["xx", "xy", "yx", "yy"])
-    sim.add("noiselike_eor", vis_filter=["xx", "yy"])
+    sim.add("noiselike_eor", vis_filter=["xx", "yy"], rng=np.random.default_rng(5))
     assert all(
         [
             np.all(sim.get_data("xx")),
@@ -621,7 +635,7 @@ def test_vis_filter_arbitrary_key():
         array_layout=hex_array(2, split_core=False, outriggers=0),
         polarization_array=["xx", "yy"],
     )
-    sim.add("noiselike_eor", vis_filter=[1, 3, 5, "xx"])
+    sim.add("noiselike_eor", vis_filter=[1, 3, 5, "xx"], rng=np.random.default_rng(7))
     bls = sim.data.get_antpairs()
     assert not np.any(sim.get_data("yy"))
     assert all(

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -285,19 +285,19 @@ def test_get_multiplicative_effect(base_sim, pol, ant1):
     gains = base_sim.add("gains", seed="once", ret_vis=True)
     _gains = base_sim.get("gains", key=(ant1, pol))
     if pol is not None and ant1 is not None:
-        assert np.allclose(gains[(ant1, pol)] == _gains)
+        assert np.allclose(gains[(ant1, pol)], _gains)
     elif pol is None and ant1 is not None:
         assert all(
-            np.allclose(gains[(ant1, _pol)] == _gains[(ant1, _pol)])
+            np.allclose(gains[(ant1, _pol)], _gains[(ant1, _pol)])
             for _pol in base_sim.data.get_feedpols()
         )
     elif pol is not None and ant1 is None:
         assert all(
-            np.allclose(gains[(ant, pol)] == _gains[(ant, pol)])
+            np.allclose(gains[(ant, pol)], _gains[(ant, pol)])
             for ant in base_sim.antpos
         )
     else:
-        assert all(np.allclose(gains[antpol] == _gains[antpol]) for antpol in gains)
+        assert all(np.allclose(gains[antpol], _gains[antpol]) for antpol in gains)
 
 
 def test_not_add_vis(base_sim):

--- a/hera_sim/tests/test_simulator.py
+++ b/hera_sim/tests/test_simulator.py
@@ -666,7 +666,7 @@ def test_bad_seeds(base_sim, seed):
         "unsupported": "Seeding mode not supported.",
     }[seed]
     with pytest.raises(err, match=match):
-        base_sim._seed_rng(seed, None)
+        base_sim._seed_rng(seed, None, model_key="test")
 
 
 def test_get_component_with_function():

--- a/hera_sim/tests/test_utils.py
+++ b/hera_sim/tests/test_utils.py
@@ -153,12 +153,12 @@ def test_rough_delay_filter_missing_param(freqs, lsts, missing_param):
 def test_delay_filter_norm(freqs):
     tsky = np.ones(freqs.size)
 
-    np.random.seed(1234)  # set the seed for reproducibility.
+    rng = np.random.default_rng(0)  # set the seed for reproducibility.
 
     out = 0
     nreal = 5000
     for _ in range(nreal):
-        _noise = tsky * utils.gen_white_noise(freqs.size)
+        _noise = tsky * utils.gen_white_noise(freqs.size, rng=rng)
         outnoise = utils.rough_delay_filter(_noise, freqs, 30, normalize=1)
 
         out += np.sum(np.abs(outnoise) ** 2)

--- a/hera_sim/tests/test_utils.py
+++ b/hera_sim/tests/test_utils.py
@@ -124,8 +124,9 @@ def test_rough_filter_noisy_data(freqs, lsts, filter_type):
             "fringe_filter_type": "gauss",
             "fr_width": 1e-4,
         }
+    rng = np.random.default_rng(0)
     for i in range(Nrealizations):
-        data = utils.gen_white_noise((lsts.size, freqs.size))
+        data = utils.gen_white_noise((lsts.size, freqs.size), rng=rng)
         filtered_data = filt(data, *args, **kwargs)
         filtered_data_mean = np.mean(filtered_data)
         mean_values[i] = filtered_data_mean.real, filtered_data_mean.imag
@@ -276,7 +277,7 @@ def test_fringe_filter_custom(freqs, lsts, fringe_rates):
 @pytest.mark.parametrize("bl_len_ns", [50, 150])
 @pytest.mark.parametrize("fr_width", [1e-4, 3e-4])
 def test_rough_fringe_filter_noisy_data(freqs, lsts, fringe_rates, bl_len_ns, fr_width):
-    data = utils.gen_white_noise((lsts.size, freqs.size))
+    data = utils.gen_white_noise((lsts.size, freqs.size), rng=np.random.default_rng(0))
     max_fringe_rates = utils.calc_max_fringe_rate(freqs, bl_len_ns)
     filt_data = utils.rough_fringe_filter(
         data, lsts, freqs, bl_len_ns, fringe_filter_type="gauss", fr_width=fr_width
@@ -333,7 +334,7 @@ def test_gen_white_noise_shape(shape):
 
 @pytest.mark.parametrize("shape", [100, (100, 200)])
 def test_gen_white_noise_mean(shape):
-    noise = utils.gen_white_noise(shape)
+    noise = utils.gen_white_noise(shape, rng=np.random.default_rng(0))
     assert np.allclose(
         [noise.mean().real, noise.mean().imag], 0, rtol=0, atol=5 / np.sqrt(noise.size)
     )
@@ -341,7 +342,7 @@ def test_gen_white_noise_mean(shape):
 
 @pytest.mark.parametrize("shape", [100, (100, 200)])
 def test_gen_white_noise_variance(shape):
-    noise = utils.gen_white_noise(shape)
+    noise = utils.gen_white_noise(shape, rng=np.random.default_rng(0))
     assert np.isclose(np.std(noise), 1, rtol=0, atol=0.1)
 
 

--- a/hera_sim/tests/test_vis.py
+++ b/hera_sim/tests/test_vis.py
@@ -37,7 +37,6 @@ if HAVE_GPU:
     SIMULATORS = SIMULATORS + (VisGPU,)
 
 
-np.random.seed(0)
 NTIMES = 10
 NPIX = 12 * 16**2
 NFREQ = 5

--- a/hera_sim/utils.py
+++ b/hera_sim/utils.py
@@ -420,7 +420,9 @@ def wrap2pipi(a):
     return res
 
 
-def gen_white_noise(size: int | tuple[int] = 1) -> np.ndarray:
+def gen_white_noise(
+    size: int | tuple[int] = 1, rng: np.random.Generator | None = None
+) -> np.ndarray:
     """Produce complex Gaussian noise with unity variance.
 
     Parameters
@@ -428,16 +430,21 @@ def gen_white_noise(size: int | tuple[int] = 1) -> np.ndarray:
     size
         Shape of output array. Can be an integer if a single dimension is required,
         otherwise a tuple of ints.
+    rng
+        Random number generator.
 
     Returns
     -------
     noise
         White noise realization with specified shape.
     """
+    # Split power evenly between real and imaginary components.
     std = 1 / np.sqrt(2)
-    return np.random.normal(scale=std, size=size) + 1j * np.random.normal(
-        scale=std, size=size
-    )
+    args = dict(scale=std, size=size)
+
+    # Create a random number generator if needed, then generate noise.
+    rng = rng or np.random.default_rng()
+    return rng.normal(**args) + 1j * rng.normal(**args)
 
 
 def jansky_to_kelvin(freqs: np.ndarray, omega_p: Beam | np.ndarray) -> np.ndarray:


### PR DESCRIPTION
This PR implements a shift to use the new API for generating random numbers with `numpy`. Now, rather than seed the global `numpy` random state prior to simulating a component, users should provide a `np.random.Generator` instance that is seeded as they desire. For folks who prefer to use the `Simulator`, then they effectively don't need to change anything&mdash;the interaction with the `Simulator` looks the same in basically every case (there are some corner cases, but, assuming I'm not missing something major, they're unusual enough that they should just be addressed in one-off conversations).

The following simple rule can be applied to update code to be compliant with this change:

**PRIOR TO THIS UPDATE**
```
seed = 12345  # or whatever you want to use
np.random.seed(seed)
cmp = sim_component(*args, **kwargs)
```


**AFTER THIS UPDATE**
```
seed = 12345  # or whatever you want to use
rng = np.random.default_rng(seed)
cmp = sim_component(*args, **kwargs, rng=rng)
```


In both cases, `args` are the positional arguments required by the simulation component's call signature, while `kwargs` are the keyword arguments that are typically stored as the class instance's attributes (i.e., these are the model parameters).

The most substantial change here is how the `Simulator` juggles random states. This is hidden from the end user, but it is worthwhile to note the changes in some detail here for those interested in how the `Simulator` internals function. Here is a high-level description of how the logic worked prior to this update, as well as a brief description of how it works after the changes made in this PR.

**PRIOR TO THIS UPDATE**

Before simulating the desired effect with the `add` method, the `Simulator` checks to see if the user has requested that the random state be managed in a particular way by checking the value of the `seed` parameter. If the user provided something, then the `Simulator` effectively enters a random state management routine before evaluating the model. Importantly, ***the random state is set during this random state management routine*** via the old API `np.random.seed(...)`. Seed caching is performed as-needed, depending on the type of seeding prescription requested.

**AFTER THIS UPDATE**

The initial logic is the same as before&mdash;the `Simulator` checks to see whether it should set the random state prior to evaluating the model. The main difference now is that the `_seed_rng` routine (the random state management routine mentioned above) returns both the (possibly updated) `seed` as well as the random number generator that has been seeded as desired. The `seed` returned is just to ensure that the `Simulator` has memory of what it was asked to do (which allows for cool stuff like making sure every baseline in a redundant group gets the same random seed, if desired), while ***the random number generator is passed along to the model and is ultimately used to make the random component of the model***.