### PR TITLE
test: fix path in broken test

### DIFF
--- a/src/hera_sim/cli_utils.py
+++ b/src/hera_sim/cli_utils.py
@@ -133,11 +133,11 @@ def write_calfits(
         if isinstance(sim, Simulator):
             freqs = sim.freqs * 1e9
             times = sim.times
-            sim_x_orientation = sim.data.x_orientation
+            sim_x_orientation = sim.data.telescope.x_orientation
         else:
             freqs = np.unique(sim.freq_array)
             times = np.unique(sim.time_array)
-            sim_x_orientation = sim.x_orientation
+            sim_x_orientation = sim.telescope.x_orientation
         if sim_x_orientation is None:
             warnings.warn(
                 "x_orientation not specified in simulation object."

--- a/src/hera_sim/io.py
+++ b/src/hera_sim/io.py
@@ -115,8 +115,8 @@ def empty_uvdata(
         uvd.fix_phase()
 
     # TODO: the following is a hack patch for pyuvsim which should be fixed there.
-    if "x_orientation" in kwargs and uvd.x_orientation is None:
-        uvd.x_orientation = kwargs["x_orientation"]
+    if "x_orientation" in kwargs and uvd.telescope.x_orientation is None:
+        uvd.telescope.x_orientation = kwargs["x_orientation"]
 
     if conjugation is not None:
         uvd.conjugate_bls(convention=conjugation)

--- a/src/hera_sim/tests/conftest.py
+++ b/src/hera_sim/tests/conftest.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 from astropy.time import Time
 from astropy.utils import iers
@@ -19,3 +21,11 @@ def setup_and_teardown_package():
     yield
 
     iers.conf.auto_max_age = 30
+
+@pytest.fixture(scope='session')
+def repodir() -> Path:
+    return Path(__file__).parent.parent.parent.parent
+
+@pytest.fixture(scope='session')
+def exampledir(repodir: Path) -> Path:
+    return repodir / 'config_examples'

--- a/src/hera_sim/tests/test_visibilities/test_matvis.py
+++ b/src/hera_sim/tests/test_visibilities/test_matvis.py
@@ -22,13 +22,12 @@ def test_stokespol(uvdata_linear, sky_model):
         )
 
 
-def test_load_from_yaml(tmpdir):
-    example_dir = Path(__file__).parent.parent.parent.parent / "config_examples"
+def test_load_from_yaml(exampledir: Path):
 
-    simulator = load_simulator_from_yaml(example_dir / "simulator.yaml")
+    simulator = load_simulator_from_yaml(exampledir / "simulator.yaml")
     assert isinstance(simulator, MatVis)
     assert simulator._precision==2
 
-    sim2 = MatVis.from_yaml(example_dir / "simulator.yaml")
+    sim2 = MatVis.from_yaml(exampledir / "simulator.yaml")
 
     assert sim2.diffuse_ability == simulator.diffuse_ability


### PR DESCRIPTION
Fixes a broken path in a test, and fixes a few warnings from accessing `uvd.x_orientation`.