### PR TITLE
feat: add npy and npz loaders as YAML tags

### DIFF
--- a/src/hera_sim/__yaml_constructors.py
+++ b/src/hera_sim/__yaml_constructors.py
@@ -8,6 +8,7 @@ import inspect
 import warnings
 
 import astropy.units as u
+import numpy as np
 import yaml
 
 from . import antpos, interpolators
@@ -70,3 +71,20 @@ def antpos_constructor(loader, node):
 
 
 yaml.add_constructor("!antpos", antpos_constructor, yaml.FullLoader)
+
+def npz_constructor(loader, node):
+    """Construct a numpy array from an .npz file."""
+    path = loader.construct_scalar(node)
+    return np.load(path, allow_pickle=True)
+
+
+yaml.add_constructor("!npz", npz_constructor, yaml.FullLoader)
+
+def npy_constructor(loader, node):
+    """Construct a numpy array from an .npy file."""
+    path = loader.construct_scalar(node)
+    return np.load(path, allow_pickle=True)
+
+yaml.add_constructor("!npy", npy_constructor, yaml.FullLoader)
+
+yaml.add_constructor("!npz", npz_constructor, yaml.FullLoader)

--- a/src/hera_sim/visibilities/simulators.py
+++ b/src/hera_sim/visibilities/simulators.py
@@ -521,7 +521,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
 def load_simulator_from_yaml(config: Path | str) -> VisibilitySimulator:
     """Construct a visibility simulator from a YAML file."""
     with open(config) as fl:
-        cfg = yaml.safe_load(fl)
+        cfg = yaml.load(fl, Loader=yaml.FullLoader)
 
     simulator_cls = cfg.pop("simulator")
 

--- a/src/hera_sim/visibilities/simulators.py
+++ b/src/hera_sim/visibilities/simulators.py
@@ -477,7 +477,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
         """Generate the simulator from a YAML file or dictionary."""
         if not isinstance(yaml_config, dict):
             with open(yaml_config) as fl:
-                yaml_config = yaml.safe_load(fl)
+                yaml_config = yaml.load(fl, Loader=yaml.FullLoader)
 
         # In general, we allow to specify which simulator to use in the config,
         # but that shouldn't be passed on to the constructor of a particular simulator.

--- a/tests/test_yaml_constructors.py
+++ b/tests/test_yaml_constructors.py
@@ -1,8 +1,13 @@
 """Module for testing the various new YAML tags in this package."""
 
+import numpy as np
 import pytest
 import yaml
 from astropy.units.quantity import Quantity
+
+# We need to import the module to register the constructors, but we don't need to use
+# it directly
+from hera_sim import __yaml_constructors as yaml_constructors
 
 
 def test_astropy_units_constructor(tmp_path):
@@ -57,3 +62,33 @@ def bad_astropy_units(tmp_path):
         with open(tfile) as f:
             yaml.load(f.read(), Loader=yaml.FullLoader)
     assert "Please check your configuration" in err.value.args[0]
+
+
+def test_npz_constructor(tmp_path):
+    arr = np.arange(10)
+    np.savez(tmp_path / "test.npz", arr=arr)
+    tfile = tmp_path / "test_npz.yaml"
+    with open(tfile, "w") as f:
+        f.write(
+            f"""
+            array: !npz {tmp_path}/test.npz
+            """
+        )
+    with open(tfile) as f:
+        mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
+    assert isinstance(mydict["array"]['arr'], np.ndarray)
+
+
+def test_npy_constructor(tmp_path):
+    arr = np.arange(10)
+    np.save(tmp_path / "test.npy", arr)
+    tfile = tmp_path / "test_npy.yaml"
+    with open(tfile, "w") as f:
+        f.write(
+            f"""
+            array: !npy {tmp_path}/test.npy
+            """
+        )
+    with open(tfile) as f:
+        mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
+    assert isinstance(mydict["array"], np.ndarray)


### PR DESCRIPTION
Adds `.npy` and `.npz` auto-loaders as YAML tags. Mostly for the purpose of being able to specify external data files in simulator configuration.