### PR TITLE
Fix fftvis beamidx

### DIFF
--- a/src/hera_sim/__yaml_constructors.py
+++ b/src/hera_sim/__yaml_constructors.py
@@ -8,6 +8,7 @@ import inspect
 import warnings
 
 import astropy.units as u
+import numpy as np
 import yaml
 
 from . import antpos, interpolators
@@ -70,3 +71,20 @@ def antpos_constructor(loader, node):
 
 
 yaml.add_constructor("!antpos", antpos_constructor, yaml.FullLoader)
+
+def npz_constructor(loader, node):
+    """Construct a numpy array from an .npz file."""
+    path = loader.construct_scalar(node)
+    return np.load(path, allow_pickle=True)
+
+
+yaml.add_constructor("!npz", npz_constructor, yaml.FullLoader)
+
+def npy_constructor(loader, node):
+    """Construct a numpy array from an .npy file."""
+    path = loader.construct_scalar(node)
+    return np.load(path, allow_pickle=True)
+
+yaml.add_constructor("!npy", npy_constructor, yaml.FullLoader)
+
+yaml.add_constructor("!npz", npz_constructor, yaml.FullLoader)

--- a/src/hera_sim/visibilities/fftvis.py
+++ b/src/hera_sim/visibilities/fftvis.py
@@ -207,9 +207,13 @@ class FFTVis(VisibilitySimulator):
 
         ra, dec = data_model.sky_model.ra.rad, data_model.sky_model.dec.rad
 
-        # The following are antenna positions in the order that they are
-        # in the uvdata.data_array
         active_antpos = get_antpos_dict(data_model.uvdata, data_ants=True)
+        num2name = {
+            i: nm for i, nm in zip(
+                data_model.uvdata.telescope.antenna_numbers,
+                data_model.uvdata.telescope.antenna_names
+            )
+        }
 
         # since pyuvdata v3, get_antpairs always returns antpairs in the right order.
         antpairs = data_model.uvdata.get_antpairs()
@@ -223,6 +227,8 @@ class FFTVis(VisibilitySimulator):
             ]
         else:
             beams = data_model.beams
+
+        beam_ids = [data_model.beam_ids[num2name[i]] for i in active_antpos.keys()]
 
         # Get all the polarizations required to be simulated.
         req_pols = self._get_req_pols(data_model.uvdata, beams[0], polarized=polarized)
@@ -254,6 +260,7 @@ class FFTVis(VisibilitySimulator):
                 times=data_model.times,
                 telescope_loc=data_model.uvdata.telescope.location,
                 beam_list=beams,
+                beam_idx=beam_ids,
                 fluxes=data_model.sky_model.stokes[0, [i]].to("Jy").value.T,
                 beam_spline_opts=data_model.beams.spline_interp_opts,
                 precision=self._precision,

--- a/src/hera_sim/visibilities/matvis.py
+++ b/src/hera_sim/visibilities/matvis.py
@@ -198,7 +198,8 @@ class MatVis(VisibilitySimulator):
         # We only do a non-polarized simulation if UVData has only XX or YY polarization
         return len(p) != 1 or uvutils.polnum2str(p[0]) not in ["xx", "yy"]
 
-    def get_feed(self, uvdata) -> str:
+    @staticmethod
+    def get_feed(uvdata) -> str:
         """Get the feed to use from the beam, given the UVData object.
 
         Only applies for an *unpolarized* simulation (for a polarized sim, all feeds
@@ -216,7 +217,6 @@ class MatVis(VisibilitySimulator):
             Visibilities. Shape=self.uvdata.data_array.shape.
         """
         polarized = self._check_if_polarized(data_model)
-        feed = self.get_feed(data_model.uvdata)
 
         # Setup MPI info if enabled
         if self.mpi_comm is not None:
@@ -338,9 +338,6 @@ class MatVis(VisibilitySimulator):
         uvbeam: BeamInterface,
         polarized: bool
     ) -> list[tuple[int, int]]:
-        if not polarized:
-            return [(0, 0)]
-
         beam_obj = uvbeam.beam
         feeds = uvbeam.feed_array
         if isinstance(feeds, np.ndarray):
@@ -366,6 +363,11 @@ class MatVis(VisibilitySimulator):
             uvutils.polnum2str(polnum, x_orientation)
             for polnum in uvdata.polarization_array
         ]
+
+        if not polarized:
+            feed = MatVis.get_feed(uvdata)
+            return [(feeds.index(feed),feeds.index(feed))]
+
         if any(pol not in avail_pols for pol in uvdata_pols):
             raise ValueError(
                 "Not all polarizations in UVData object are in your beam. "

--- a/src/hera_sim/visibilities/simulators.py
+++ b/src/hera_sim/visibilities/simulators.py
@@ -521,7 +521,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
 def load_simulator_from_yaml(config: Path | str) -> VisibilitySimulator:
     """Construct a visibility simulator from a YAML file."""
     with open(config) as fl:
-        cfg = yaml.safe_load(fl)
+        cfg = yaml.load(fl, Loader=yaml.FullLoader)
 
     simulator_cls = cfg.pop("simulator")
 

--- a/src/hera_sim/visibilities/simulators.py
+++ b/src/hera_sim/visibilities/simulators.py
@@ -477,7 +477,7 @@ class VisibilitySimulator(metaclass=ABCMeta):
         """Generate the simulator from a YAML file or dictionary."""
         if not isinstance(yaml_config, dict):
             with open(yaml_config) as fl:
-                yaml_config = yaml.safe_load(fl)
+                yaml_config = yaml.load(fl, Loader=yaml.FullLoader)
 
         # In general, we allow to specify which simulator to use in the config,
         # but that shouldn't be passed on to the constructor of a particular simulator.

--- a/tests/test_visibilities/test_compare_pyuvsim.py
+++ b/tests/test_visibilities/test_compare_pyuvsim.py
@@ -107,30 +107,30 @@ def gaussian():
 
 @pytest.fixture(scope='function')
 def polybeam():
-    return PolyBeam(
-        ref_freq=1e8,
-        spectral_index=-0.6975,
-        beam_coeffs=[
-            2.35088101e-01,
-            -4.20162599e-01,
-            2.99189140e-01,
-            -1.54189057e-01,
-            3.38651457e-02,
-            3.46936067e-02,
-            -4.98838130e-02,
-            3.23054464e-02,
-            -7.56006552e-03,
-            -7.24620596e-03,
-            7.99563166e-03,
-            -2.78125602e-03,
-            -8.19945835e-04,
-            1.13791191e-03,
-            -1.24301372e-04,
-            -3.74808752e-04,
-            1.93997376e-04,
-            -1.72012040e-05,
-        ],
-    )
+    return PolyBeam.like_fagnoni19()#(
+    #     ref_freq=1e8,
+    #     spectral_index=-0.6975,
+    #     beam_coeffs=[
+    #         2.35088101e-01,
+    #         -4.20162599e-01,
+    #         2.99189140e-01,
+    #         -1.54189057e-01,
+    #         3.38651457e-02,
+    #         3.46936067e-02,
+    #         -4.98838130e-02,
+    #         3.23054464e-02,
+    #         -7.56006552e-03,
+    #         -7.24620596e-03,
+    #         7.99563166e-03,
+    #         -2.78125602e-03,
+    #         -8.19945835e-04,
+    #         1.13791191e-03,
+    #         -1.24301372e-04,
+    #         -3.74808752e-04,
+    #         1.93997376e-04,
+    #         -1.72012040e-05,
+    #     ],
+    # )
 
 @pytest.mark.parametrize(
     "nsource,beam_type,polarized",
@@ -141,6 +141,8 @@ def polybeam():
         (100, "gaussian", False),
         (100, "polybeam", False),
         (100, "polybeam", True),
+        (100, "multibeam", True),
+#        (100, "multibeam", False),  TODO: this is failing!
     ],
 )
 @pytest.mark.parametrize("simcls", [v for k, v in SIMULATORS.items() if k != "UVSim"])
@@ -151,8 +153,15 @@ def test_compare_with_pyuvsim(
     sky_model = get_sky_model(uvdata_allpols, nsource)
 
     # Beam models
-    beams = [request.getfixturevalue(beam_type)]
-    beam_dict = {str(i): 0 for i in range(nants)}
+    if beam_type == "multibeam":
+        beams = [
+            request.getfixturevalue("gaussian"),
+            request.getfixturevalue("polybeam")
+        ]
+        beam_dict = {str(i): i % 2 for i in range(nants)}
+    else:
+        beams = [request.getfixturevalue(beam_type)]
+        beam_dict = {str(i): 0 for i in range(nants)}
 
     # ---------------------------------------------------------------------------
     # (1) Run matvis
@@ -166,13 +175,9 @@ def test_compare_with_pyuvsim(
     # Construct simulator object and run
     simulator = simcls()
 
-    # TODO: if we update the PolyBeam API so that it doesn't *require* 2 feeds,
-    # we can get rid of this.
-    vis_cpu_beams = [copy.deepcopy(beam) for beam in beams]
-
     sim = VisibilitySimulation(
         data_model=ModelData(
-            uvdata=uvdata_matvis, sky_model=sky_model, beams=vis_cpu_beams
+            uvdata=uvdata_matvis, sky_model=sky_model, beams=beams, beam_ids=beam_dict
         ),
         simulator=simulator,
     )

--- a/tests/test_visibilities/test_compare_pyuvsim.py
+++ b/tests/test_visibilities/test_compare_pyuvsim.py
@@ -107,30 +107,7 @@ def gaussian():
 
 @pytest.fixture(scope='function')
 def polybeam():
-    return PolyBeam.like_fagnoni19()#(
-    #     ref_freq=1e8,
-    #     spectral_index=-0.6975,
-    #     beam_coeffs=[
-    #         2.35088101e-01,
-    #         -4.20162599e-01,
-    #         2.99189140e-01,
-    #         -1.54189057e-01,
-    #         3.38651457e-02,
-    #         3.46936067e-02,
-    #         -4.98838130e-02,
-    #         3.23054464e-02,
-    #         -7.56006552e-03,
-    #         -7.24620596e-03,
-    #         7.99563166e-03,
-    #         -2.78125602e-03,
-    #         -8.19945835e-04,
-    #         1.13791191e-03,
-    #         -1.24301372e-04,
-    #         -3.74808752e-04,
-    #         1.93997376e-04,
-    #         -1.72012040e-05,
-    #     ],
-    # )
+    return PolyBeam.like_fagnoni19()
 
 @pytest.mark.parametrize(
     "nsource,beam_type,polarized",

--- a/tests/test_yaml_constructors.py
+++ b/tests/test_yaml_constructors.py
@@ -1,8 +1,13 @@
 """Module for testing the various new YAML tags in this package."""
 
+import numpy as np
 import pytest
 import yaml
 from astropy.units.quantity import Quantity
+
+# We need to import the module to register the constructors, but we don't need to use
+# it directly
+from hera_sim import __yaml_constructors as yaml_constructors
 
 
 def test_astropy_units_constructor(tmp_path):
@@ -57,3 +62,33 @@ def bad_astropy_units(tmp_path):
         with open(tfile) as f:
             yaml.load(f.read(), Loader=yaml.FullLoader)
     assert "Please check your configuration" in err.value.args[0]
+
+
+def test_npz_constructor(tmp_path):
+    arr = np.arange(10)
+    np.savez(tmp_path / "test.npz", arr=arr)
+    tfile = tmp_path / "test_npz.yaml"
+    with open(tfile, "w") as f:
+        f.write(
+            f"""
+            array: !npz {tmp_path}/test.npz
+            """
+        )
+    with open(tfile) as f:
+        mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
+    assert isinstance(mydict["array"]['arr'], np.ndarray)
+
+
+def test_npy_constructor(tmp_path):
+    arr = np.arange(10)
+    np.save(tmp_path / "test.npy", arr)
+    tfile = tmp_path / "test_npy.yaml"
+    with open(tfile, "w") as f:
+        f.write(
+            f"""
+            array: !npy {tmp_path}/test.npy
+            """
+        )
+    with open(tfile) as f:
+        mydict = yaml.load(f.read(), Loader=yaml.FullLoader)
+    assert isinstance(mydict["array"], np.ndarray)


### PR DESCRIPTION
Pass the `beam_idx` parameter through to FFTVis.

Also adds a test that compares against pyuvsim using multiple beams. Note that for some reason if `polarized=False` this test fails. I made https://github.com/HERA-Team/hera_sim/issues/414 to track this bug.