### PR TITLE
Precompute __antpair2ind_cache

### DIFF
--- a/src/hera_sim/utils.py
+++ b/src/hera_sim/utils.py
@@ -751,6 +751,46 @@ def tanh_window(x, x_min=None, x_max=None, scale_low=1, scale_high=1):
     return window
 
 
+def precompute_antpair_index_cache(uvdata):
+    """Precompute the antpair2ind cache to reduce simulation setup costs.
+
+    The validation step performed during the initialization of a
+    ``visibilities.VisibilitySimulation`` object performs a check that the
+    baseline conjugation convention does not change with time. Under the hood,
+    this involves repeatedly calling ``UVData.antpair2ind``, which is very
+    inefficient for large N arrays---for the full HERA core, this can take
+    roughly 10 minutes. Precomputing the cache mapping antenna pairs to
+    blt-axis slices, which this function does, can drastically reduce that cost.
+    For non-rectangular baseline-times, the overall cost of precomputing the
+    cache and then validating the simulation parameters is expected to not be
+    reduced relative to validating the simulation without cache precomputation.
+
+    Parameters
+    ----------
+    uvdata
+        The UVData object whose antpair2ind cache should be updated.
+    """
+    antpair2ind_cache = uvdata._UVData__antpair2ind_cache
+    all_antpairs = set(uvdata.get_antpairs())  # set lookup is faster than list
+    for idx, (ai, aj) in enumerate(uvdata.get_antpairs()):
+        if uvdata.blts_are_rectangular:
+            if uvdata.time_axis_faster_than_bls:
+                antpair2ind_cache[(ai,aj,True)] = slice(
+                    idx*uvdata.Ntimes, (idx+1) * uvdata.Ntimes
+                )
+            else:
+                antpair2ind_cache[(ai,aj,True)] = slice(idx, None, uvdata.Nbls)
+        else:
+            idx = np.where(
+                (uvdata.ant_1_array == ai) & (uvdata.ant_2_array == aj)
+            )[0]
+            uvdata._UVData__antpair2ind_cache[(ai,aj,True)] = uvutils.tools.slicify(idx)
+        if ai != aj and (aj,ai) not in all_antpairs:
+            uvdata._UVData__antpair2ind_cache[(aj,ai,True)] = None
+
+    return
+
+
 # Just some numba-fied helpful functions.
 # Note that coverage can't see that these are run without disabling JIT,
 # which kind of defeats the purpose of testing it.

--- a/src/hera_sim/visibilities/fftvis.py
+++ b/src/hera_sim/visibilities/fftvis.py
@@ -101,14 +101,8 @@ class FFTVis(VisibilitySimulator):
 
         if self.check_antenna_conjugation:
             logger.info("Checking antenna conjugation")
-            # TODO: the following is extremely slow. If possible, it would be good to
-            # find a better way to do it.
-            if any(
-                data_model.uvdata.antpair2ind(ai, aj) is not None
-                and data_model.uvdata.antpair2ind(aj, ai) is not None
-                for ai, aj in data_model.uvdata.get_antpairs()
-                if ai != aj
-            ):
+            antpairs = set(data_model.uvdata.get_antpairs())
+            if any((aj, ai) in antpairs for (ai, aj) in antpairs if ai != aj):
                 raise ValueError(
                     "FFTVis requires that baselines be in a conjugation in which "
                     "antenna order doesn't change with time!"

--- a/src/hera_sim/visibilities/matvis.py
+++ b/src/hera_sim/visibilities/matvis.py
@@ -24,6 +24,7 @@ from pyuvdata import BeamInterface, UVData
 from pyuvdata import utils as uvutils
 
 from .simulators import ModelData, VisibilitySimulator
+from .. import utils
 
 logger = logging.getLogger(__name__)
 
@@ -131,14 +132,8 @@ class MatVis(VisibilitySimulator):
 
         if self.check_antenna_conjugation:
             logger.info("Checking antenna conjugation")
-            # TODO: the following is extremely slow. If possible, it would be good to
-            # find a better way to do it.
-            if any(
-                data_model.uvdata.antpair2ind(ai, aj) is not None
-                and data_model.uvdata.antpair2ind(aj, ai) is not None
-                for ai, aj in data_model.uvdata.get_antpairs()
-                if ai != aj
-            ):
+            antpairs = set(data_model.uvdata.get_antpairs())
+            if any((aj, ai) in antpairs for (ai, aj) in antpairs if ai != aj):
                 raise ValueError(
                     "MatVis requires that baselines be in a conjugation in which "
                     "antenna order doesn't change with time!"
@@ -334,6 +329,9 @@ class MatVis(VisibilitySimulator):
             f"Pols = {req_pols}. blt_order = {uvdata.blt_order}"
         )
 
+        # Repeatedly calling antpair2ind is expensive if the cache hasn't
+        # yet been built. So we precompute it to speed this part up.
+        utils.precompute_antpair_index_cache(uvdata)
         for i, (ant1, ant2) in enumerate(uvdata.get_antpairs()):
             # get all blt indices corresponding to this antpair
             indx = uvdata.antpair2ind(ant1, ant2)

--- a/src/hera_sim/visibilities/matvis.py
+++ b/src/hera_sim/visibilities/matvis.py
@@ -23,8 +23,8 @@ except ImportError:  # pragma: no cover
 from pyuvdata import BeamInterface, UVData
 from pyuvdata import utils as uvutils
 
-from .simulators import ModelData, VisibilitySimulator
 from .. import utils
+from .simulators import ModelData, VisibilitySimulator
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -6,9 +6,10 @@ from astropy import units
 from pyuvdata import utils as uvutils
 
 from hera_sim import DATA_PATH, Simulator, defaults, utils
+from hera_sim.antpos import hex_array
 from hera_sim.interpolators import Beam
 from hera_sim.io import empty_uvdata
-from hera_sim.antpos import hex_array
+
 
 @pytest.fixture(scope="function")
 def lsts():

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -471,8 +471,10 @@ def test_precompute_antpair_index_cache(uvdata, conj, slow_axis):
         conj = np.argwhere(uvdata.time_array == t0).flatten()
         uvdata.blts_are_rectangular = False  # UVData should do this, but it doesn't.
 
-    # Tinker with the ordering of things.
+    # Tinker with the ordering of things; conjugate *then* reorder.
+    # Swapping the order means the wrong baselines get conjugated.
     uvdata.conjugate_bls(conj)
+    uvdata.reorder_blts(slow_axis)
     utils.precompute_antpair_index_cache(uvdata)
     antpair2ind_cache = uvdata._UVData__antpair2ind_cache.copy()
     uvdata._clear_antpair2ind_cache(uvdata)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,7 +7,8 @@ from pyuvdata import utils as uvutils
 
 from hera_sim import DATA_PATH, Simulator, defaults, utils
 from hera_sim.interpolators import Beam
-
+from hera_sim.io import empty_uvdata
+from hera_sim.antpos import hex_array
 
 @pytest.fixture(scope="function")
 def lsts():
@@ -30,6 +31,20 @@ def freqs():
 def delays(freqs):
     df = np.mean(np.diff(freqs))
     return np.fft.fftfreq(freqs.size, df)
+
+
+@pytest.fixture(scope="function")
+def uvdata():
+    array_layout = hex_array(3, split_core=False, outriggers=0)
+    return empty_uvdata(
+        array_layout=array_layout,
+        Ntimes=3,
+        start_time=2458210.0496,
+        integration_time=10,
+        Nfreqs=1,
+        start_freq=150e6,
+        channel_width=100e3,
+    )
 
 
 @pytest.mark.parametrize("bl_len_ns", [50, 100])
@@ -444,3 +459,34 @@ class TestGetAntposDict:
     def test_bad_frame(self):
         with pytest.raises(ValueError, match="frame must be"):
             utils.get_antpos_dict(None, frame='bad_frame')
+
+@pytest.mark.parametrize(
+    "conj", ["ant1<ant2", "ant2<ant1", "u<0", "v<0", "u>0", "v>0", "nontrivial"]
+)
+@pytest.mark.parametrize("slow_axis", ["time", "baseline"])
+def test_precompute_antpair_index_cache(uvdata, conj, slow_axis):
+    # Conjugate baselines at one particular time.
+    if conj == "nontrivial":
+        t0 = np.unique(uvdata.time_array)[1]
+        conj = np.argwhere(uvdata.time_array == t0).flatten()
+        uvdata.blts_are_rectangular = False  # UVData should do this, but it doesn't.
+
+    # Tinker with the ordering of things.
+    uvdata.conjugate_bls(conj)
+    utils.precompute_antpair_index_cache(uvdata)
+    antpair2ind_cache = uvdata._UVData__antpair2ind_cache.copy()
+    uvdata._clear_antpair2ind_cache(uvdata)
+
+    # Now check that the slices are correct.
+    all_correct = True
+    ant_1_array = uvdata.ant_1_array
+    ant_2_array = uvdata.ant_2_array
+    for ai, aj in uvdata.get_antpairs():
+        cache_slice = antpair2ind_cache[(ai, aj, True)]
+        uvdata_slice = uvdata.antpair2ind(ai, aj)
+        all_correct &= (
+            np.all(ant_1_array[cache_slice] == ant_1_array[uvdata_slice])
+        ) and (
+            np.all(ant_2_array[cache_slice] == ant_2_array[uvdata_slice])
+        )
+    assert all_correct


### PR DESCRIPTION
Validating the `ModelData` object can be needlessly expensive when setting up simulations at the scale of full HERA because of the check that only one of `(ai, aj)` or `(aj, ai)` show up for any antenna pair. This workaround can avoid the problem by precomputing the antenna pair to baseline-time index cache.

Unfortunately, after writing and testing this, I have come to the realization that we can probably speed up the code block in the validation section (e.g., [here](https://github.com/HERA-Team/hera_sim/blob/14a8080a58777ee4a25e68af67bb07a2e18c5767/src/hera_sim/visibilities/fftvis.py#L102)) with something like
```
antpairs = set(uvdata.get_antpairs())
if any((aj,ai) in antpairs for (ai,aj) in antpairs if ai != aj):
    raise ValueError(...)
```
instead of checking that either `uvdata.antpair2ind(ai,aj)` or `uvdata.antpair2ind(aj,ai)` returns `None`. The only corner case that I *think* I can see where this fails would be something like the `"nontrivial"` case in my tests that exclude setting the `blts_are_rectangular` attribute to `False` (while also having time as the fast part of the baseline-time axis). Although I think that case would fail silently, as it would ultimately tie back to `uvdata.get_antpairs()` not returning the full list of antenna pairs.